### PR TITLE
feat: お手伝い登録画面にAdMobバナー広告を追加 (#10)

### DIFF
--- a/app/OtetsudaiCoin.xcodeproj/project.pbxproj
+++ b/app/OtetsudaiCoin.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D5A61F032E0100FB00C8C1E9 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = D5A61F022E0100FB00C8C1E9 /* GoogleMobileAds */; };
 		D5F61E0B2DFE70FB00C8C1E9 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = D5F61E0A2DFE70FB00C8C1E9 /* ViewInspector */; };
 /* End PBXBuildFile section */
 
@@ -33,9 +34,22 @@
 		D5F61D882DFE693E00C8C1E9 /* OtetsudaiCoinUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OtetsudaiCoinUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		D5A61F042E0101DE00C8C1E9 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = D5F61D6B2DFE693C00C8C1E9 /* OtetsudaiCoin */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		D5F61D6E2DFE693C00C8C1E9 /* OtetsudaiCoin */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				D5A61F042E0101DE00C8C1E9 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
+			);
 			path = OtetsudaiCoin;
 			sourceTree = "<group>";
 		};
@@ -56,6 +70,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5A61F032E0100FB00C8C1E9 /* GoogleMobileAds in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +140,7 @@
 			);
 			name = OtetsudaiCoin;
 			packageProductDependencies = (
+				D5A61F022E0100FB00C8C1E9 /* GoogleMobileAds */,
 			);
 			productName = OtetsudaiCoin;
 			productReference = D5F61D6C2DFE693C00C8C1E9 /* OtetsudaiCoin.app */;
@@ -211,6 +227,7 @@
 			mainGroup = D5F61D632DFE693C00C8C1E9;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				D5A61F012E0100DE00C8C1E9 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
 				D5F61E082DFE70DE00C8C1E9 /* XCRemoteSwiftPackageReference "ViewInspector" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -418,6 +435,7 @@
 				DEVELOPMENT_TEAM = UUD4WPFJTD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OtetsudaiCoin/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -447,6 +465,7 @@
 				DEVELOPMENT_TEAM = UUD4WPFJTD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OtetsudaiCoin/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -580,6 +599,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		D5A61F012E0100DE00C8C1E9 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.2.0;
+			};
+		};
 		D5F61E082DFE70DE00C8C1E9 /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nalexn/ViewInspector";
@@ -591,6 +618,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		D5A61F022E0100FB00C8C1E9 /* GoogleMobileAds */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D5A61F012E0100DE00C8C1E9 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
+			productName = GoogleMobileAds;
+		};
 		D5F61E0A2DFE70FB00C8C1E9 /* ViewInspector */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D5F61E082DFE70DE00C8C1E9 /* XCRemoteSwiftPackageReference "ViewInspector" */;

--- a/app/OtetsudaiCoin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/OtetsudaiCoin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "7abf1dd76d62709d50ab97ba7b5907de6a95cbc813d2bf154db0688b92d85914",
+  "originHash" : "6e8858ed3df0764e84d0cde05acf3f52edc5e087fba15189452e039699f6f0cc",
   "pins" : [
+    {
+      "identity" : "swift-package-manager-google-mobile-ads",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
+      "state" : {
+        "revision" : "1239c23464503053c17d37ee5daa70de3455e9c8",
+        "version" : "12.14.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-user-messaging-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+      "state" : {
+        "revision" : "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
+        "version" : "3.1.0"
+      }
+    },
     {
       "identity" : "viewinspector",
       "kind" : "remoteSourceControl",

--- a/app/OtetsudaiCoin/AppDelegate.swift
+++ b/app/OtetsudaiCoin/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import UserNotifications
+import GoogleMobileAds
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
@@ -8,6 +9,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        MobileAds.shared.start(completionHandler: nil)
         return true
     }
 

--- a/app/OtetsudaiCoin/Info.plist
+++ b/app/OtetsudaiCoin/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>GADApplicationIdentifier</key>
+	<string>ca-app-pub-3940256099942544~1458002511</string>
+</dict>
+</plist>

--- a/app/OtetsudaiCoin/Presentation/Components/BannerAdView.swift
+++ b/app/OtetsudaiCoin/Presentation/Components/BannerAdView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import GoogleMobileAds
+
+struct BannerAdView: UIViewRepresentable {
+
+    func makeUIView(context: Context) -> BannerView {
+        let bannerView = BannerView(adSize: AdSizeBanner)
+        bannerView.adUnitID = AdConstants.testBannerAdUnitID
+        bannerView.load(Request())
+        return bannerView
+    }
+
+    func updateUIView(_ uiView: BannerView, context: Context) {}
+}

--- a/app/OtetsudaiCoin/Presentation/Views/TaskManagementView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/TaskManagementView.swift
@@ -29,7 +29,7 @@ struct TaskManagementView: View {
                                     showingDeleteAlert = true
                                 }
                             }
-                            
+
                             Button(action: {
                                 showingAddTaskForm = true
                             }) {
@@ -42,6 +42,9 @@ struct TaskManagementView: View {
                         }
                     }
                 }
+
+                BannerAdView()
+                    .frame(height: 50)
             }
             .navigationTitle("お手伝い管理")
             .navigationBarTitleDisplayMode(.inline)

--- a/app/OtetsudaiCoin/Utils/AdConstants.swift
+++ b/app/OtetsudaiCoin/Utils/AdConstants.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum AdConstants {
+    static let testBannerAdUnitID = "ca-app-pub-3940256099942544/2934735716"
+}

--- a/app/OtetsudaiCoinTests/Presentation/Components/BannerAdViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/BannerAdViewTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import OtetsudaiCoin
+
+final class BannerAdViewTests: XCTestCase {
+
+    // MARK: - インスタンス生成
+
+    @MainActor
+    func testBannerAdViewCanBeInstantiated() {
+        // Given/When: BannerAdView を生成
+        let view = BannerAdView()
+
+        // Then: インスタンスが生成される
+        XCTAssertNotNil(view)
+    }
+
+    // MARK: - SwiftUIビューとしての埋め込み
+
+    @MainActor
+    func testBannerAdViewCanBeEmbeddedInVStack() throws {
+        // Given: BannerAdView を VStack に埋め込んだレイアウト
+        let container = VStack {
+            Text("Content")
+            BannerAdView()
+                .frame(height: 50)
+        }
+
+        // When: ビュー階層を検査
+        let inspected = try container.inspect()
+
+        // Then: VStack 内にビューが存在する
+        XCTAssertNoThrow(try inspected.find(text: "Content"))
+    }
+
+    // MARK: - TaskManagementView との統合
+
+    @MainActor
+    func testTaskManagementViewContainsBannerAdView() throws {
+        // Given: TaskManagementView のための依存を準備
+        let mockRepository = MockHelpTaskRepository()
+        let viewModel = TaskManagementViewModel(helpTaskRepository: mockRepository)
+
+        // When: TaskManagementView を生成
+        let view = TaskManagementView(viewModel: viewModel)
+
+        // Then: BannerAdView が含まれている
+        XCTAssertNoThrow(try view.inspect().find(BannerAdView.self))
+    }
+
+    @MainActor
+    func testTaskManagementViewShowsBannerAdBelowList() throws {
+        // Given: タスクが存在する状態
+        let mockRepository = MockHelpTaskRepository()
+        mockRepository.tasks = [
+            HelpTask(id: UUID(), name: "お皿洗い", isActive: true, coinRate: 10)
+        ]
+        let viewModel = TaskManagementViewModel(helpTaskRepository: mockRepository)
+        viewModel.tasks = mockRepository.tasks
+
+        // When: TaskManagementView を生成
+        let view = TaskManagementView(viewModel: viewModel)
+
+        // Then: リストとバナー広告の両方が含まれている
+        XCTAssertNoThrow(try view.inspect().find(ViewType.List.self))
+        XCTAssertNoThrow(try view.inspect().find(BannerAdView.self))
+    }
+
+    @MainActor
+    func testTaskManagementViewShowsBannerAdDuringLoadingState() throws {
+        // Given: ローディング中の状態
+        let mockRepository = MockHelpTaskRepository()
+        let viewModel = TaskManagementViewModel(helpTaskRepository: mockRepository)
+        viewModel.isLoading = true
+
+        // When: TaskManagementView を生成
+        let view = TaskManagementView(viewModel: viewModel)
+
+        // Then: ローディング中でもバナー広告が表示される
+        XCTAssertNoThrow(try view.inspect().find(BannerAdView.self))
+    }
+}


### PR DESCRIPTION
## Summary

- GoogleMobileAds SDK (v12.14.0) を Swift Package Manager で導入
- `BannerAdView` を `UIViewRepresentable` で実装し SwiftUI に統合
- `TaskManagementView` のリスト下部に高さ 50px で配置（操作の邪魔にならない位置）
- `AppDelegate` で `MobileAds.shared.start()` を呼び出し初期化
- `Info.plist` に `GADApplicationIdentifier` を設定
- `BannerAdViewTests` で 5 ケースの単体テストを追加

## Test plan

- [ ] Xcode でビルドが成功すること
- [ ] `BannerAdViewTests` の 5 ケースがパスすること
- [ ] シミュレータまたは実機で TaskManagementView（お手伝い管理画面）の最下部にAdMobのテストバナーが表示されること
- [ ] バナーが List のスクロールやタスク追加・削除操作を阻害しないこと

## 注意事項

現在使用しているのは Google 公式のテスト用 ID です：
- バナー広告ユニット ID: `ca-app-pub-3940256099942544/2934735716`
- アプリ ID: `ca-app-pub-3940256099942544~1458002511`

**本番リリース前に実 ID への差し替えが必要**です。フォローアップタスクとして別途対応予定。
また、AdMob のパーソナライズ広告を有効化する場合は App Tracking Transparency (ATT) 対応も別途必要になります。

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)