### PR TITLE
feat: AdMob を Non-personalized 広告で運用 (npa=1) (#22)

### DIFF
--- a/app/OtetsudaiCoin/Presentation/Components/BannerAdView.swift
+++ b/app/OtetsudaiCoin/Presentation/Components/BannerAdView.swift
@@ -6,9 +6,23 @@ struct BannerAdView: UIViewRepresentable {
     func makeUIView(context: Context) -> BannerView {
         let bannerView = BannerView(adSize: AdSizeBanner)
         bannerView.adUnitID = AdConstants.testBannerAdUnitID
-        bannerView.load(Request())
+        bannerView.load(Self.makeNonPersonalizedRequest())
         return bannerView
     }
 
     func updateUIView(_ uiView: BannerView, context: Context) {}
+
+    // Issue #22: ATT 対応として Non-personalized 広告のみで運用する。
+    // 起動時にトラッキング許可ダイアログを出さず、IDFA を利用しない設定で広告を要求する。
+    static func makeNonPersonalizedExtras() -> Extras {
+        let extras = Extras()
+        extras.additionalParameters = ["npa": "1"]
+        return extras
+    }
+
+    static func makeNonPersonalizedRequest() -> Request {
+        let request = Request()
+        request.register(makeNonPersonalizedExtras())
+        return request
+    }
 }

--- a/app/OtetsudaiCoinTests/Presentation/Components/BannerAdViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/BannerAdViewTests.swift
@@ -1,9 +1,30 @@
 import XCTest
 import SwiftUI
 import ViewInspector
+import GoogleMobileAds
 @testable import OtetsudaiCoin
 
 final class BannerAdViewTests: XCTestCase {
+
+    // MARK: - Non-personalized 広告リクエスト
+
+    @MainActor
+    func testNonPersonalizedExtrasHasNpaParameter() {
+        // Given/When: Non-personalized 用の Extras を生成
+        let extras = BannerAdView.makeNonPersonalizedExtras()
+
+        // Then: npa=1 が含まれている（IDFA を使わないトラッキング無し広告）
+        XCTAssertEqual(extras.additionalParameters?["npa"] as? String, "1")
+    }
+
+    @MainActor
+    func testNonPersonalizedRequestIsCreated() {
+        // Given/When: Non-personalized 用の Request を生成
+        let request = BannerAdView.makeNonPersonalizedRequest()
+
+        // Then: Request が生成される
+        XCTAssertNotNil(request)
+    }
 
     // MARK: - インスタンス生成
 

--- a/docs/superpowers/specs/2026-05-11-att-non-personalized-design.md
+++ b/docs/superpowers/specs/2026-05-11-att-non-personalized-design.md
@@ -35,14 +35,16 @@ request.register(extras)
 bannerView.load(request)
 ```
 
-### 2. Privacy Manifest を追加
+### 2. Privacy Manifest（フォローアップに分離）
 
-`PrivacyInfo.xcprivacy` をプロジェクトに追加し、以下を明示:
+`PrivacyInfo.xcprivacy` の追加は Xcode プロジェクトのターゲットメンバーシップ設定が必要で、`npa=1` 実装とは関心領域が異なる。別フォローアップ Issue（または `#22` の追加 PR）として分離する。
+
+宣言予定の内容:
 
 - `NSPrivacyTracking = false`（トラッキングしない）
 - `NSPrivacyTrackingDomains = []`
-- `NSPrivacyCollectedDataTypes = []`（アプリ本体は IDFA 等を収集しない。AdMob SDK 側の宣言は別途 SDK 同梱の Privacy Manifest が担う）
-- `NSPrivacyAccessedAPITypes` … 該当 API 利用に対するリーズンコード（UserDefaults 等）
+- `NSPrivacyCollectedDataTypes = []`（アプリ本体は IDFA 等を収集しない。AdMob SDK 側の宣言は同梱 Privacy Manifest が担う）
+- `NSPrivacyAccessedAPITypes` … UserDefaults 利用に `CA92.1`（Access info from same app）
 
 ### 3. やらないこと
 
@@ -69,12 +71,14 @@ bannerView.load(request)
 - `Info.plist` の `NSUserTrackingUsageDescription`（日英ローカライズ）
 - `PrivacyInfo.xcprivacy` の `NSPrivacyTracking = true` 化と `NSPrivacyTrackingDomains` 設定
 
-## 実装タスク
+## 実装タスク（本 PR）
 
-- [ ] `Request` 生成ロジックを `BannerAdView` から抽出し、テスト可能な関数に切り出す
-- [ ] `Extras` で `npa=1` を付与する実装
-- [ ] テストを追加（`additionalParameters` に `npa=1` が含まれる）
-- [ ] `PrivacyInfo.xcprivacy` を新規追加
-- [ ] Xcode プロジェクトに `PrivacyInfo.xcprivacy` を含める（手動ステップが必要な場合はユーザー依頼）
-- [ ] `xcodebuild test` 全 PASS 確認
+- [x] `Request` 生成ロジックを `BannerAdView` から `static` メソッドに抽出
+- [x] `Extras` で `npa=1` を付与する実装
+- [x] テストを追加（`additionalParameters` に `npa=1` が含まれる）
+- [x] `xcodebuild test` で BannerAdView 全 7 件 PASS 確認
 - [ ] コミット → PR 作成
+
+## フォローアップ（別 PR）
+
+- [ ] `PrivacyInfo.xcprivacy` を新規追加（Xcode のターゲット追加が必要）

--- a/docs/superpowers/specs/2026-05-11-att-non-personalized-design.md
+++ b/docs/superpowers/specs/2026-05-11-att-non-personalized-design.md
@@ -1,0 +1,80 @@
+# ATT 対応方針（Non-personalized 広告で初回リリース）— 設計書
+
+Issue: #22
+作成日: 2026-05-11
+
+## 背景
+
+#10（PR #17）で AdMob バナー広告を導入。iOS 14+ では広告トラッキング（IDFA）利用時に App Tracking Transparency (ATT) の許可ダイアログ表示が必須。本プロジェクトでは、初回リリースに向けて **Non-personalized 広告（IDFA を利用しない）** のみで運用する方針を採る。
+
+`plans/partitioned-baking-dawn.md` の Phase 1 検討結果。
+
+## 方針判断
+
+**採用: 案A（Non-personalized のみ）**
+
+理由:
+
+- 家庭での親子利用が主なターゲット層であり、起動直後の「トラッキング許可」ダイアログは UX 上違和感が大きい
+- 初回リリース時は DL 数が伸びる前で、ATT/UMP 周りの不備がストアレビュー低下に直結しやすい
+- 将来 DAU が伸びてからパーソナライズ広告へ切り替え可能（後方互換）
+
+## 実装スコープ
+
+### 1. AdMob リクエストに `npa=1` を付与
+
+`BannerAdView.swift` で `Request` を作る際に `Extras` を `register` し、`additionalParameters` に `["npa": "1"]` を渡す。
+
+GoogleMobileAds SDK 12.x の Swift API:
+
+```swift
+let extras = Extras()
+extras.additionalParameters = ["npa": "1"]
+let request = Request()
+request.register(extras)
+bannerView.load(request)
+```
+
+### 2. Privacy Manifest を追加
+
+`PrivacyInfo.xcprivacy` をプロジェクトに追加し、以下を明示:
+
+- `NSPrivacyTracking = false`（トラッキングしない）
+- `NSPrivacyTrackingDomains = []`
+- `NSPrivacyCollectedDataTypes = []`（アプリ本体は IDFA 等を収集しない。AdMob SDK 側の宣言は別途 SDK 同梱の Privacy Manifest が担う）
+- `NSPrivacyAccessedAPITypes` … 該当 API 利用に対するリーズンコード（UserDefaults 等）
+
+### 3. やらないこと
+
+- `Info.plist` への `NSUserTrackingUsageDescription` 追加 → ATT ダイアログを呼ばないため不要
+- `ATTrackingManager.requestTrackingAuthorization` の呼び出し
+- UMP SDK（`UserMessagingPlatform`）の利用 → GDPR consent form を出さない（Non-personalized なら不要）
+
+## 関連ファイル
+
+- `app/OtetsudaiCoin/Presentation/Components/BannerAdView.swift` — `Request` 生成箇所
+- `app/OtetsudaiCoin/Info.plist` — トラッキング関連キーは追加しない
+- `app/OtetsudaiCoin/PrivacyInfo.xcprivacy` — 新規追加
+
+## 検証
+
+- 単体テスト: `Extras` の `additionalParameters` に `npa=1` が含まれることを検証（`BannerAdView` のロジック切り出しが必要）
+- ビルド: Debug / Release 両方で警告なくビルドできること
+- 実機: バナー広告が表示されること（テスト ID 環境）
+
+## 将来の Personalized 切替に向けた TODO
+
+- UMP SDK 統合（GDPR consent form）
+- `ATTrackingManager.requestTrackingAuthorization` の起動時呼び出し
+- `Info.plist` の `NSUserTrackingUsageDescription`（日英ローカライズ）
+- `PrivacyInfo.xcprivacy` の `NSPrivacyTracking = true` 化と `NSPrivacyTrackingDomains` 設定
+
+## 実装タスク
+
+- [ ] `Request` 生成ロジックを `BannerAdView` から抽出し、テスト可能な関数に切り出す
+- [ ] `Extras` で `npa=1` を付与する実装
+- [ ] テストを追加（`additionalParameters` に `npa=1` が含まれる）
+- [ ] `PrivacyInfo.xcprivacy` を新規追加
+- [ ] Xcode プロジェクトに `PrivacyInfo.xcprivacy` を含める（手動ステップが必要な場合はユーザー依頼）
+- [ ] `xcodebuild test` 全 PASS 確認
+- [ ] コミット → PR 作成


### PR DESCRIPTION
## Summary

- ATT 対応方針として **Non-personalized 広告のみで初回リリース**（IDFA 不使用、ATT ダイアログを呼ばない）を採用
- `BannerAdView` に `Extras` の `npa=1` を付与した `Request` を作る static メソッドを追加し、`load` に渡す
- 設計書 (`docs/superpowers/specs/2026-05-11-att-non-personalized-design.md`) で方針・トレードオフ・将来 Personalized へ切り替える際の TODO を明文化

理由（家庭向けアプリの初回リリースに最適化）:
- 起動直後のトラッキング許可ダイアログは親子利用の UX 上違和感が大きい
- ATT/UMP 周りの実装・審査リスクを最小化できる
- 将来 DAU が伸びてからパーソナライズ広告へ切り替え可能

## Test plan

- [x] `xcodebuild test -only-testing:OtetsudaiCoinTests/BannerAdViewTests` で BannerAdView 全 7 件 PASS（新規 2 件含む）
- [ ] マージ後、Debug ビルドの実機でテストバナー広告が表示されることを確認
- [ ] CI 全テスト PASS

## Follow-up

本 PR スコープ外:
- `PrivacyInfo.xcprivacy` の追加（Xcode ターゲット追加が必要なため別 PR で対応）
- AdMob 本番 ID への差し替えと xcconfig 化（#21）

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)