### PR TITLE
feat: Privacy Manifest 追加 (#22 フォローアップ)

### DIFF
--- a/app/OtetsudaiCoin/PrivacyInfo.xcprivacy
+++ b/app/OtetsudaiCoin/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- ATT 対応 (#22) のフォローアップ。アプリ本体の Privacy Manifest を新規追加。
- 内容: `NSPrivacyTracking = false`、UserDefaults 使用に対するリーズンコード `CA92.1` を宣言。
- `OtetsudaiCoin/PrivacyInfo.xcprivacy` に配置するだけで、Xcode の `PBXFileSystemSynchronizedRootGroup` により**自動的にターゲットに含まれる**ことを確認済み（手動 Xcode 操作は不要）。

## 関連

- PR #26（ATT 方針決定 + npa=1 実装）と独立。両方マージで Issue #22 を完全クローズ可能。

## Test plan

- [x] `xcodebuild build` 成功
- [x] ビルド成果物 `.app/PrivacyInfo.xcprivacy` が存在し、`plutil -lint` で OK
- [x] BannerAdView 既存テスト 5 件 PASS（回帰なし）
- [ ] CI 全テスト PASS
- [ ] App Store Connect への TestFlight アップロード時に Privacy Manifest 関連の警告が出ないこと

Closes #22 (PR #26 と合わせて)

🤖 Generated with [Claude Code](https://claude.com/claude-code)