### PR TITLE
fix: 履歴画面のデータロードを .task に統一、履歴のデフォルトフィルタを過去3か月に (#32, #33)

### DIFF
--- a/app/OtetsudaiCoin/Presentation/ViewModels/HelpHistoryViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/HelpHistoryViewModel.swift
@@ -6,7 +6,7 @@ import Combine
 class HelpHistoryViewModel {
     var helpRecords: [HelpRecordWithDetails] = []
     var selectedChild: Child?
-    var selectedPeriod: HistoryPeriod = .thisMonth
+    var selectedPeriod: HistoryPeriod = .last3Months
     var isLoading: Bool = false
     var errorMessage: String?
     
@@ -34,11 +34,8 @@ class HelpHistoryViewModel {
                 }
             }
             .store(in: &cancellables)
-        
-        // 初期データの読み込み
-        Task {
-            await loadInitialData()
-        }
+
+        // 初期データは View 側の .task で loadInitialData() を明示呼び出しする責務に変更（#32）
     }
     
     deinit {

--- a/app/OtetsudaiCoin/Presentation/ViewModels/MonthlyHistoryViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/MonthlyHistoryViewModel.swift
@@ -83,13 +83,8 @@ class MonthlyHistoryViewModel {
     }
     
     func selectChild(_ child: Child) {
+        // データロードは View 側の .task で明示呼び出しする責務に変更（#33: sheet 初回表示時の二重 fetch を避ける）
         selectedChild = child
-        // 即座にデータロードを実行
-        Task {
-            await MainActor.run {
-                loadMonthlyHistory()
-            }
-        }
     }
     
     func loadMonthlyHistory() {

--- a/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
@@ -67,8 +67,10 @@ struct HelpHistoryView: View {
                 recordToEdit = nil
             }
         }
-        .onAppear {
+        .task {
+            // #32: 初期ロードを View 側の `.task` に統一（ViewModel init からの auto-Task を廃止）
             loadAvailableChildren()
+            await viewModel.loadInitialData()
         }
     }
     
@@ -167,15 +169,30 @@ struct HelpHistoryView: View {
             Image(systemName: "list.clipboard")
                 .font(.system(size: 60))
                 .foregroundColor(.secondary)
-            
-            Text("お手伝い記録がありません")
+
+            // #32: 「全データが無い」ではなく「今のフィルタには無い」ことを明示
+            Text("「\(viewModel.selectedPeriod.rawValue)」の記録はありません")
                 .font(.title2)
                 .fontWeight(.semibold)
-            
-            Text("選択した期間にお手伝いの記録がありません。\n記録タブから新しいお手伝いを記録してみましょう！")
+                .multilineTextAlignment(.center)
+
+            Text("期間を変えて過去の記録を探すか、記録タブから新しいお手伝いを記録してみましょう！")
                 .font(.body)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
+
+            if viewModel.selectedPeriod != .all {
+                Button {
+                    viewModel.selectedPeriod = .all
+                    viewModel.selectPeriod(.all)
+                } label: {
+                    Text("全期間で表示する")
+                        .font(.body)
+                        .fontWeight(.semibold)
+                }
+                .primaryGradientButton()
+                .padding(.top, 8)
+            }
         }
         .padding(.horizontal, 40)
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/app/OtetsudaiCoin/Presentation/Views/MonthlyHistoryView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/MonthlyHistoryView.swift
@@ -59,14 +59,9 @@ struct MonthlyHistoryView: View {
                 viewModel.refreshData()
             }
         }
-        .onAppear {
-            // selectedChildがセットされているか確認してからデータロード
-            if viewModel.selectedChild != nil && viewModel.monthlyRecords.isEmpty {
-                viewModel.refreshData()
-            } else if viewModel.selectedChild == nil {
-                // 子供が選択されていない場合のログ
-                print("Warning: MonthlyHistoryView appeared but selectedChild is nil")
-            }
+        .task {
+            // #33: ロードトリガを `.task` に統一して、ViewModel 側 selectChild の auto-Task と二重起動するのを防ぐ
+            viewModel.refreshData()
         }
         .alert("エラー", isPresented: .constant(viewModel.errorMessage != nil)) {
             Button("OK") {

--- a/app/OtetsudaiCoinTests/Presentation/ViewModels/HelpHistoryViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/ViewModels/HelpHistoryViewModelTests.swift
@@ -45,9 +45,36 @@ final class HelpHistoryViewModelTests: XCTestCase {
     func testSelectPeriod() {
         // When
         viewModel.selectPeriod(.thisWeek)
-        
+
         // Then
         XCTAssertEqual(viewModel.selectedPeriod, .thisWeek)
+    }
+
+    // #32: 過去日付登録された記録が初期表示で見えない問題を防ぐため、デフォルトを過去3か月にする
+    @MainActor
+    func testDefaultSelectedPeriodIsLast3Months() {
+        XCTAssertEqual(viewModel.selectedPeriod, .last3Months)
+    }
+
+    // #32: init 内で勝手に loadInitialData() が走らないこと（View 側 .task から明示的に呼ぶ設計）
+    @MainActor
+    func testInitDoesNotAutoLoadInitialData() async {
+        // Given: mock に子供を仕込んだ状態でも、init 単独では auto-load されないこと
+        let child = Child(id: UUID(), name: "太郎", themeColor: "#FF5733")
+        mockChildRepository.children = [child]
+
+        let freshViewModel = HelpHistoryViewModel(
+            helpRecordRepository: mockHelpRecordRepository,
+            helpTaskRepository: mockHelpTaskRepository,
+            childRepository: mockChildRepository
+        )
+
+        // 旧設計なら init 内の Task { await loadInitialData() } が動いて selectedChild がセットされる
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then: selectedChild は nil のまま（View 側で明示的に loadInitialData() を呼ぶ責務）
+        XCTAssertNil(freshViewModel.selectedChild)
+        XCTAssertTrue(freshViewModel.helpRecords.isEmpty)
     }
     
     @MainActor

--- a/app/OtetsudaiCoinTests/Presentation/ViewModels/MonthlyHistoryViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/ViewModels/MonthlyHistoryViewModelTests.swift
@@ -50,11 +50,38 @@ final class MonthlyHistoryViewModelTests: XCTestCase {
     @MainActor
     func testSelectChild() {
         let child = Child(id: UUID(), name: "太郎", themeColor: "#FF5733")
-        
+
         viewModel.selectChild(child)
-        
+
         XCTAssertEqual(viewModel.selectedChild?.id, child.id)
         XCTAssertEqual(viewModel.selectedChild?.name, "太郎")
+    }
+
+    // #33: selectChild は selectedChild をセットするだけで loadMonthlyHistory を自動起動しない
+    // （初回 sheet 表示で起こる二重 fetch / 表示崩れを防ぐため、ロードは View 側 .task の責務）
+    @MainActor
+    func testSelectChildDoesNotAutoLoad() async {
+        let child = Child(id: UUID(), name: "太郎", themeColor: "#FF5733")
+        let calendar = Calendar.current
+        let lastMonth = calendar.date(byAdding: .month, value: -1, to: Date())!
+        let helpRecord = HelpRecord(
+            id: UUID(),
+            childId: child.id,
+            helpTaskId: UUID(),
+            recordedAt: lastMonth
+        )
+        mockHelpRecordRepository.records = [helpRecord]
+        mockAllowanceCalculator.monthlyAllowance = 100
+
+        viewModel.selectChild(child)
+
+        // 旧設計は selectChild 内の Task が 100ms 程度で完了して monthlyRecords が埋まっていた
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        // Then: selectedChild はセット、しかし fetch は走っていないので monthlyRecords は空
+        XCTAssertEqual(viewModel.selectedChild?.id, child.id)
+        XCTAssertTrue(viewModel.monthlyRecords.isEmpty)
+        XCTAssertFalse(viewModel.isLoading)
     }
     
     @MainActor
@@ -81,17 +108,19 @@ final class MonthlyHistoryViewModelTests: XCTestCase {
             expectedAmount: 100
         )
         mockUnpaidDetector.unpaidPeriods = [unpaidPeriod]
-        
+
         viewModel.selectChild(child)
-        
+        // #33 以後の設計: 明示的に loadMonthlyHistory() を呼ぶ（View 側 .task の責務に揃える）
+        viewModel.loadMonthlyHistory()
+
         // 非同期処理完了を待つ
         try? await Task.sleep(nanoseconds: 100_000_000) // 0.1秒待機
-        
+
         // 検証
         XCTAssertFalse(viewModel.monthlyRecords.isEmpty)
         XCTAssertEqual(viewModel.unpaidRecords.count, 1)
         XCTAssertEqual(viewModel.totalUnpaidAmount, 100)
-        
+
         let unpaidRecord = viewModel.unpaidRecords.first!
         XCTAssertTrue(unpaidRecord.isUnpaid)
         XCTAssertEqual(unpaidRecord.unpaidAmount, 100)
@@ -182,12 +211,14 @@ final class MonthlyHistoryViewModelTests: XCTestCase {
         
         // 未支払い期間なし
         mockUnpaidDetector.unpaidPeriods = []
-        
+
         viewModel.selectChild(child)
-        
+        // #33 以後の設計: 明示的に loadMonthlyHistory() を呼ぶ（View 側 .task の責務に揃える）
+        viewModel.loadMonthlyHistory()
+
         // 非同期処理完了を待つ
         try? await Task.sleep(nanoseconds: 100_000_000) // 0.1秒待機
-        
+
         // 検証
         XCTAssertFalse(viewModel.monthlyRecords.isEmpty)
         XCTAssertTrue(viewModel.unpaidRecords.isEmpty) // 未支払い記録なし


### PR DESCRIPTION
## Summary

v1.1.0 残オープン Issue 対応プラン Phase A の実装。履歴系画面のバグ #33 / #32 を一括対応。

- **#33 月別履歴の初回表示問題**: HomeView → `selectChild()` で auto-Task が起動 → sheet 表示 → `.onAppear` で再ロード → `loadHistoryTask.cancel()` の競合で初回 sheet 描画が「履歴がありません」に落ちていた。`selectChild` から auto-Task を削除し、データロードを `MonthlyHistoryView` の `.task` modifier に一本化。
- **#32 履歴で「お手伝い記録がありません」誤表示**: デフォルト selectedPeriod が `.thisMonth` 固定で、過去日付登録 (#20) した記録が初期表示で見えなかった。デフォルトを `.last3Months` に変更 + `HelpHistoryViewModel.init` 内の auto-Task を廃止し View 側の `.task` に統一 + 空状態 UI に「全期間で表示する」フォールバックボタンを追加。

詳細プラン: `plans/github-issue-recursive-oasis.md` (Phase A)

## TDD

すべての変更は失敗するテスト → 修正のサイクルで実装:

- 新規 RED テスト (3 件) → 実装後 GREEN:
  - `HelpHistoryViewModelTests.testDefaultSelectedPeriodIsLast3Months`
  - `HelpHistoryViewModelTests.testInitDoesNotAutoLoadInitialData`
  - `MonthlyHistoryViewModelTests.testSelectChildDoesNotAutoLoad`
- 既存テスト 2 件を新仕様に追従 (selectChild の後に明示的に `loadMonthlyHistory()` を呼ぶ形へ):
  - `MonthlyHistoryViewModelTests.testLoadMonthlyHistoryWithUnpaidRecords`
  - `MonthlyHistoryViewModelTests.testLoadMonthlyHistoryWithFullyPaidRecords`

## Test plan

- [x] `xcodebuild test` 全 `OtetsudaiCoinTests` 緑（既存 pre-existing failure 2 件を除く）
  - **本 PR スコープ外で元から失敗していたテスト 2 件** (別 issue 化推奨):
    - `LocalizationStringCatalogTests.testAllKeysHaveEnglishTranslation` — String Catalog の `開発者向け` 等の英訳欠落（DEBUG 機能用文言の整備漏れ）
    - `HomeViewTests.testHomeViewDisplaysUnpaidWarningBannerWithoutSelectedChild` — ViewInspector 系の UI 検証エラー
- [ ] **未実施: Simulator での目視動作確認** (※ Claude 側で実機 UI のフィードバックループが取れないため、レビュー時にお手元での確認をお願いします)
  - [ ] アプリを kill 後、新規起動 → ホームから月別履歴を初回起動で開く → 履歴が即表示されることを確認（#33）
  - [ ] 過去日付（前月）でお手伝い登録 → お手伝い履歴画面を開く → デフォルト「過去3か月」フィルタでその記録が見えること（#32）
  - [ ] 履歴画面で期間を「今週」にして空にしたとき、「全期間で表示する」ボタンが出て、押すと全期間に切り替わること（#32 空状態導線）

## Notes

- ViewModel レイヤーは TDD + ユニットテストで挙動検証済み
- View レイヤーの変更は `.onAppear` → `.task` への置き換えが主で、SwiftUI 標準モディファイアの差し替えのみ
- Phase B (#31 評価ボタンフォールバック) / Phase C (#30 app-ads.txt) は後続 PR で対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)