### PR TITLE
fix: アプリバージョン表示と HomeView 初回ロード (#45, #44)

### DIFF
--- a/app/OtetsudaiCoin/Presentation/ViewModels/HomeViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/HomeViewModel.swift
@@ -70,24 +70,30 @@ class HomeViewModel {
     // タスクはViewModelのライフサイクルとともに自動的にキャンセルされる
     
     func loadChildren() {
+        Task {
+            await loadChildrenAsync()
+        }
+    }
+
+    // #44: View 側の `.task` から明示的に await できる async 版。
+    // 内部の `Task { }` を経由しないため、SwiftUI の `.task` ライフサイクルでキャンセル制御できる。
+    func loadChildrenAsync() async {
         isLoading = true
         errorMessage = nil
-        
-        Task {
-            do {
-                let loadedChildren = try await childRepository.findAll()
-                children = loadedChildren
-                
-                // 未支払いのお小遣いがあるかチェック
-                if !children.isEmpty {
-                    await checkUnpaidAllowances()
-                }
-                
-                isLoading = false
-            } catch {
-                errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
-                isLoading = false
+
+        do {
+            let loadedChildren = try await childRepository.findAll()
+            children = loadedChildren
+
+            // 未支払いのお小遣いがあるかチェック
+            if !children.isEmpty {
+                await checkUnpaidAllowances()
             }
+
+            isLoading = false
+        } catch {
+            errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
+            isLoading = false
         }
     }
     

--- a/app/OtetsudaiCoin/Presentation/Views/HomeView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HomeView.swift
@@ -66,8 +66,11 @@ struct HomeView: View {
                 }
             }
             .navigationTitle("おてつだいコイン")
-            .onAppear {
-                viewModel.loadChildren()
+            .task {
+                // #44: 初期ロードを View 側の `.task` に統一（履歴系画面と同じパターン）。
+                // `.onAppear` から fire-and-forget の Task 起動だと、NotificationManager 経由の
+                // 自動再ロードと競合してメイン画面が空表示のまま固定されるケースが残っていた。
+                await viewModel.loadChildrenAsync()
             }
         }
         .alert("エラー", isPresented: .constant(viewModel.errorMessage != nil)) {

--- a/app/OtetsudaiCoin/Presentation/Views/SettingsView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/SettingsView.swift
@@ -50,7 +50,14 @@ struct SettingsView: View {
             wrappedValue: PaymentReminderNotificationSettingsViewModel(service: paymentService)
         )
     }
-    
+
+    private var appVersionText: String {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "—"
+        let build = info?[kCFBundleVersionKey as String] as? String ?? "—"
+        return "\(version) (\(build))"
+    }
+
     var body: some View {
         NavigationStack {
             List {
@@ -187,7 +194,7 @@ struct SettingsView: View {
                             .foregroundColor(.blue)
                         Text("バージョン")
                         Spacer()
-                        Text("1.0.0")
+                        Text(appVersionText)
                             .foregroundColor(.secondary)
                     }
                     

--- a/app/OtetsudaiCoinTests/Presentation/HomeViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/HomeViewModelTests.swift
@@ -46,8 +46,33 @@ final class HomeViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isLoading)
         XCTAssertNil(viewModel.errorMessage)
     }
-    
-    
+
+    // #44: View 側の `.task` から呼ばれる loadChildrenAsync の挙動を確認
+    @MainActor
+    func testLoadChildrenAsyncPopulatesChildrenAndFinishesLoading() async {
+        let child1 = Child(id: UUID(), name: "太郎", themeColor: "#FF5733")
+        let child2 = Child(id: UUID(), name: "花子", themeColor: "#33FF57")
+        mockChildRepository.children = [child1, child2]
+
+        await viewModel.loadChildrenAsync()
+
+        XCTAssertEqual(viewModel.children.count, 2)
+        XCTAssertEqual(viewModel.children.map { $0.id }, [child1.id, child2.id])
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    @MainActor
+    func testLoadChildrenAsyncSurfacesErrorMessageOnFailure() async {
+        mockChildRepository.shouldThrowError = true
+
+        await viewModel.loadChildrenAsync()
+
+        XCTAssertTrue(viewModel.children.isEmpty)
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+
     @MainActor
     func testSelectChild() {
         let child = Child(id: UUID(), name: "太郎", themeColor: "#FF5733")


### PR DESCRIPTION
## Summary
- **#45**: SettingsView のバージョン表示が `Text(\"1.0.0\")` でハードコードされていたのを Bundle.main から動的取得 (`1.1.0 (36)` 形式) に変更。
- **#44**: HomeView 初回ロードを `.onAppear` → `.task` に統一。履歴系画面 (#32, #33 / d6525b9) と同じパターンを適用し、`loadChildrenAsync()` を ViewModel に追加。

Closes #45
Closes #44

## 変更ファイル
- `OtetsudaiCoin/Presentation/Views/SettingsView.swift` — `appVersionText` computed プロパティ追加、`Text(appVersionText)` に置換
- `OtetsudaiCoin/Presentation/ViewModels/HomeViewModel.swift` — `loadChildrenAsync()` を抽出。`loadChildren()` は `Task { await loadChildrenAsync() }` のラッパに変更（既存呼び出し点との互換維持）
- `OtetsudaiCoin/Presentation/Views/HomeView.swift` — `.onAppear` → `.task { await viewModel.loadChildrenAsync() }`
- `OtetsudaiCoinTests/Presentation/HomeViewModelTests.swift` — `loadChildrenAsync` の成功系・失敗系テスト 2 件追加

## Test plan
- [x] `xcodebuild test -only-testing:OtetsudaiCoinTests/HomeViewModelTests` で全 10 件 PASS (新規 2 件含む)
- [x] `xcodebuild test` 全体実行 (失敗 2 件は main baseline でも同じ失敗 = 既存問題、本 PR と無関係)
  - `HomeViewTests/testHomeViewDisplaysUnpaidWarningBannerWithoutSelectedChild` (locale 指定漏れによる ViewInspector 問題)
  - `LocalizationStringCatalogTests/testAllKeysHaveEnglishTranslation` (Issue #43 そのもの)
- [x] シミュレータ (iPhone 17) でビルド・インストール・起動 → ホーム到達確認
- [x] terminate → launch を 3 回繰り返し、ホーム空表示の regression なし（「お子様を登録してください」プレースホルダが毎回正常表示）

## 注意点
- #44 は再現条件不明のバグのため、d6525b9 のパターン適用による best-effort 修正です。冷起動 3 回で regression が出ないことは確認済みですが、ユーザー報告と同条件（子供登録後の状態）での再現確認まではできていません。マージ後の実機 TestFlight ビルドで継続観察できると安心です。
- `NotificationManager.observeChildrenUpdates` 経由の自動再ロードは引き続き同期版 `loadChildren()` を呼びますが、これは pre-change と同じ振る舞いで意図的に維持しています。

## スコープ外（別タスクで対応）
- #43 ローカライゼーション漏れ（特に MonthlyRetrospectiveView 等）
- #18 / #16 UI/UX & AppIcon リニューアル

🤖 Generated with [Claude Code](https://claude.com/claude-code)