### PR TITLE
fix: P0/P1 ローカライゼーション漏れの埋め戻し (#43)

### DIFF
--- a/app/OtetsudaiCoin/Domain/Services/PaymentReminderNotificationService.swift
+++ b/app/OtetsudaiCoin/Domain/Services/PaymentReminderNotificationService.swift
@@ -96,7 +96,7 @@ class PaymentReminderNotificationService: PaymentReminderNotificationServiceProt
         let trigger = UNCalendarNotificationTrigger(dateMatching: triggerComponents, repeats: false)
 
         let content = UNMutableNotificationContent()
-        content.title = "お小遣いの未払いがあります 💰"
+        content.title = String(localized: "お小遣いの未払いがあります 💰")
         content.body = body
         content.sound = .default
 
@@ -110,13 +110,31 @@ class PaymentReminderNotificationService: PaymentReminderNotificationServiceProt
 
     private func buildBody(for unpaid: [(child: Child, period: UnpaidPeriod)]) -> String {
         let total = unpaid.reduce(0) { $0 + $1.period.expectedAmount }
-        let parts = unpaid.map { "\($0.child.name)\($0.period.month)月分(¥\($0.period.expectedAmount))" }
 
         if unpaid.count == 1 {
             let item = unpaid[0]
-            return "\(item.child.name)の\(item.period.month)月分 ¥\(item.period.expectedAmount) が未払いです"
+            return String(
+                format: String(localized: "%1$@の%2$lld月分 ¥%3$lld が未払いです"),
+                item.child.name,
+                item.period.month,
+                item.period.expectedAmount
+            )
         }
-        return parts.joined(separator: "、") + " が未払いです（合計 ¥\(total)）"
+
+        let parts = unpaid.map {
+            String(
+                format: String(localized: "%1$@%2$lld月分(¥%3$lld)"),
+                $0.child.name,
+                $0.period.month,
+                $0.period.expectedAmount
+            )
+        }
+        let joined = parts.joined(separator: String(localized: "、"))
+        return String(
+            format: String(localized: "%1$@ が未払いです（合計 ¥%2$lld）"),
+            joined,
+            total
+        )
     }
 
     private func nextMonthFirstComponents(hour: Int, minute: Int) -> DateComponents {

--- a/app/OtetsudaiCoin/Domain/Services/ReminderNotificationService.swift
+++ b/app/OtetsudaiCoin/Domain/Services/ReminderNotificationService.swift
@@ -87,8 +87,8 @@ class ReminderNotificationService: ReminderNotificationServiceProtocol {
 
     func scheduleDaily() async throws {
         let content = UNMutableNotificationContent()
-        content.title = "おてつだいコイン"
-        content.body = "今日のお手伝いを記録しよう！🌟"
+        content.title = String(localized: "おてつだいコイン")
+        content.body = String(localized: "今日のお手伝いを記録しよう！🌟")
         content.sound = .default
 
         var dateComponents = DateComponents()

--- a/app/OtetsudaiCoin/Resources/Localizable.xcstrings
+++ b/app/OtetsudaiCoin/Resources/Localizable.xcstrings
@@ -15,7 +15,14 @@
       }
     },
     "%@ちゃんの記録" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@'s records"
+          }
+        }
+      }
     },
     "%@のお小遣い%lldコインを支払いますか？" : {
       "localizations" : {
@@ -43,7 +50,14 @@
 
     },
     "%lld回" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld times"
+          }
+        }
+      }
     },
     "+%lld" : {
 
@@ -52,7 +66,14 @@
 
     },
     "3ヶ月分サンプルデータ生成" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generate 3-month sample data"
+          }
+        }
+      }
     },
     "OK" : {
       "localizations" : {
@@ -928,7 +949,14 @@
       }
     },
     "ホーム" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        }
+      }
     },
     "ホーム画面" : {
       "extractionState" : "stale",
@@ -983,7 +1011,14 @@
       }
     },
     "リマインド通知" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder notifications"
+          }
+        }
+      }
     },
     "一部支払い済み" : {
       "localizations" : {
@@ -1154,7 +1189,14 @@
       }
     },
     "全データ削除" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete all data"
+          }
+        }
+      }
     },
     "全期間" : {
       "extractionState" : "stale",
@@ -1774,7 +1816,14 @@
       }
     },
     "記録" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Record"
+          }
+        }
+      }
     },
     "記録する" : {
       "localizations" : {
@@ -1818,7 +1867,14 @@
       }
     },
     "記録データのみ削除" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete records only"
+          }
+        }
+      }
     },
     "記録ボタンをタップ" : {
       "extractionState" : "stale",
@@ -1960,16 +2016,44 @@
       }
     },
     "通知" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        }
+      }
     },
     "通知を有効にする" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable notifications"
+          }
+        }
+      }
     },
     "通知時間" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notification time"
+          }
+        }
+      }
     },
     "通知設定" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notification settings"
+          }
+        }
+      }
     },
     "連続記録" : {
       "extractionState" : "stale",
@@ -2027,7 +2111,14 @@
       }
     },
     "開発者向け" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Developer"
+          }
+        }
+      }
     },
     "App Store でレビューする" : {
       "localizations" : {
@@ -2035,6 +2126,215 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Review on the App Store"
+          }
+        }
+      }
+    },
+    "データがありません" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No data available"
+          }
+        }
+      }
+    },
+    "振り返り" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retrospective"
+          }
+        }
+      }
+    },
+    "獲得" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Earned"
+          }
+        }
+      }
+    },
+    "ハイライト" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Highlights"
+          }
+        }
+      }
+    },
+    "連続" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streak"
+          }
+        }
+      }
+    },
+    "頑張った日" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Best day"
+          }
+        }
+      }
+    },
+    "ベスト" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top task"
+          }
+        }
+      }
+    },
+    "%lld日 (%lld回)" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Day %1$lld (%2$lld times)"
+          }
+        }
+      }
+    },
+    "お手伝い内訳" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Help breakdown"
+          }
+        }
+      }
+    },
+    "まだ記録がありません" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No records yet"
+          }
+        }
+      }
+    },
+    "%@のカレンダー" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ calendar"
+          }
+        }
+      }
+    },
+    "お小遣いを渡す" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay allowance"
+          }
+        }
+      }
+    },
+    "支払いリマインド" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment reminders"
+          }
+        }
+      }
+    },
+    "今日のお手伝いを記録しよう！🌟" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Let's record today's help! 🌟"
+          }
+        }
+      }
+    },
+    "お小遣いの未払いがあります 💰" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unpaid allowance 💰"
+          }
+        }
+      }
+    },
+    "%1$@の%2$lld月分 ¥%3$lld が未払いです" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@'s allowance for month %2$lld (¥%3$lld) is unpaid"
+          }
+        }
+      }
+    },
+    "%1$@%2$lld月分(¥%3$lld)" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ month %2$lld (¥%3$lld)"
+          }
+        }
+      }
+    },
+    "%1$@ が未払いです（合計 ¥%2$lld）" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ are unpaid (total ¥%2$lld)"
+          }
+        }
+      }
+    },
+    "、" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", "
           }
         }
       }


### PR DESCRIPTION
## Summary
- 新機能 (振り返し画面) や常時表示 (タブラベル) を含む **P0/P1 のローカライゼーション漏れ** を埋め戻し。
- 通知サービス 2 件は `String(localized:)` ラップ + `String(format:)` で語順差異に対応。
- 英訳は AI 提案ベース。**レビューで違和感ある訳があれば指摘してください 🙏**

Refs #43

## スコープ
| 区分 | 対象 | 状態 |
|---|---|---|
| P0 | ContentView タブラベル (`ホーム` / `記録` / `設定`) | ✅ |
| P0 | MonthlyRetrospectiveView (振り返し画面ほぼ全テキスト) | ✅ |
| P1 | SettingsView (Section/ボタン/Section ヘッダー) | ✅ |
| P1 | NotificationSettingsView (Section/Toggle/DatePicker/navigationTitle) | ✅ |
| P1 | ReminderNotificationService (通知タイトル+本文) | ✅ |
| P1 | PaymentReminderNotificationService (通知タイトル+動的本文) | ✅ |
| P2 | alert メッセージ群、HelpTask デフォルト値、`%lld` 等汎用プレースホルダ | ⏸ 別 issue 推奨 |

## 変更ファイル
- `OtetsudaiCoin/Resources/Localizable.xcstrings` — 新規キー 19 件追加 + 既存 13 件に英訳補完。**既存翻訳 14 件のスタイル (Capital Case 等) は保護**
- `OtetsudaiCoin/Domain/Services/ReminderNotificationService.swift` — title/body を `String(localized:)` 化
- `OtetsudaiCoin/Domain/Services/PaymentReminderNotificationService.swift` — title を `String(localized:)` 化、`buildBody()` を `String(format: String(localized:), ...)` 形式に再構成し、位置指定パラメータ `%1$@` / `%2$lld` / `%3$lld` で英訳側の語順差異 (例: 「太郎の8月分」→ "Taro's allowance for month 8") に対応

## 設計メモ: なぜ Swift 側はほぼ無修正なのか
SwiftUI の `Text(_:)` / `Section(_:)` / `Toggle(_:)` / `DatePicker(_:)` / `Button(_:)` / `.navigationTitle(_:)` は `LocalizedStringKey` を受ける init が選ばれるため、`Text(\"ホーム\")` のままで xcstrings に \"ホーム\" → \"Home\" を登録すれば自動的に切替が効きます。文字列補間も `Text(\"\\(child.name)ちゃんの記録\")` が LocalizedStringKey(\"%@ちゃんの記録\") として扱われ、xcstrings 側に `%@ちゃんの記録` キーがあれば英訳が出ます。

例外は `UNMutableNotificationContent.title/body` のような **String 直接代入**箇所のみで、これは `String(localized:)` でラップする必要があります。

## Test plan
- [x] `xcodebuild test -only-testing:OtetsudaiCoinTests/LocalizationStringCatalogTests` 全 13 件中 12 件 PASS
  - `testAllKeysHaveEnglishTranslation` は本 PR で **失敗 13 件減少**（残 20 件は P2 スコープのキー: alert メッセージ、`%lld` 等汎用プレースホルダ）
- [x] フルユニットテスト実行: HomeViewModelTests を含む全テストで本 PR による regression なし
  - 残失敗 2 件は main 時点と同じ既存問題 (`HomeViewTests/testHomeViewDisplaysUnpaidWarningBannerWithoutSelectedChild` の locale 指定漏れ + `testAllKeysHaveEnglishTranslation`)
- [x] iPhone 17 シミュレータで日本語ロケール起動: タブとプレースホルダが日本語表示
- [x] iPhone 17 シミュレータで英語ロケール起動 (`-AppleLanguages '(en)'`): タブが Home/Record/Settings、プレースホルダが "Please register a child"、ナビタイトル "OtetsudaiCoin" に変化

## レビュー観点
1. **英訳の自然さ**: 特に「お小遣い」(allowance) や「お手伝い」(help) の訳語選定、振り返し画面のセクション名 ("Highlights" / "Top task" 等)、通知本文の語順
2. **既存スタイルの保護**: 既存 en 翻訳のうち Capital Case (例: \"Child Management\", \"Add New Child\") をあえて維持しています。新規追加分は lower-case を採用 — スタイル統一すべきか別 issue とすべきか
3. **PaymentReminderNotificationService.buildBody**: 単数/複数で format string を切り替える設計。`Locale` ごとの単複規則 (英語の plural 等) には未対応 (Apple の inflection / plural rules 機能は P2 範囲)

## スコープ外（残課題）
別 issue で対応推奨:
- alert / confirmation メッセージ群 (\"%@ を削除しますか？\" 等)
- HelpTask.defaultTasks() の初期タスク名 10 件
- HelpHistoryViewModel.FilterPeriod enum の rawValue を UI から分離するリファクタ
- 汎用プレースホルダ (\"%lld\" / \"+%lld\" / \"1.0.0\") の `shouldTranslate: false` マーク化

🤖 Generated with [Claude Code](https://claude.com/claude-code)