### PR TITLE
docs: issue-triage-rules.md を steering に追加

### DIFF
--- a/.kiro/steering/issue-triage-rules.md
+++ b/.kiro/steering/issue-triage-rules.md
@@ -1,0 +1,75 @@
+---
+inclusion: manual
+---
+
+# Issue Triage Rules (OtetsudaiCoin 固有)
+
+このファイルは `daily-issue-triage` skill が動いた際に **手動参照** されるプロジェクト固有ルール集です。汎用スキルでは扱わない OtetsudaiCoin の語彙・運用規約をここに集約します。
+
+`daily-issue-triage` を呼び出された Claude は、最初にこのファイルを読んでから tabulation・scope 確認に進んでください。
+
+## 優先度の語彙
+
+セッション内で P0/P1/P2 と呼ばれることがあります。意味は:
+
+| ラベル | 意味 | 例 |
+| --- | --- | --- |
+| **P0** | 即対応 / リリースブロッキング | アプリがクラッシュする / 起動できない / ストア審査リジェクト |
+| **P1** | 次リリースで必須 | 主要画面の表示バグ / 新機能のローカライズ漏れ / アクセシビリティ不足 |
+| **P2** | 保留可能 / 別バージョンで検討 | デザイン要件未定の UI 改善 / 汎用プレースホルダの i18n 整備 |
+
+ユーザーから「P0 / P1 / P2」と言われたらこの定義で受け取る。`gh issue` の label には現状この prefix はないので、優先度は会話で明示される運用。
+
+## リリースバージョン規約
+
+セマンティックバージョニング (`vMAJOR.MINOR.PATCH`):
+
+- **PATCH** (例: `1.1.0` → `1.1.1`): バグ修正のみ
+- **MINOR** (例: `1.1.x` → `1.2.0`): 後方互換のある機能追加 / 大きめの改善
+- **MAJOR** (例: `1.x.x` → `2.0.0`): 互換性のない変更 (アプリレベルでは UI/UX フルリニューアル相当)
+
+リリース手順書は `RELEASE_vX.Y.Z.md` を毎リリース新規作成。前バージョンの md は残す。
+
+**重要**: リリース PR では `MARKETING_VERSION` と `CURRENT_PROJECT_VERSION` の bump を必ず確認。これは `release-version-bump-check` skill の領域。
+
+## ラベル運用
+
+リポジトリで使われているラベル (`gh label list`):
+
+- `bug` — バグ修正系
+- `enhancement` — 新機能・改善
+- `documentation` — ドキュメント・リリース手順
+- `question` — 仕様確認 / 議論
+- `duplicate` / `wontfix` / `invalid` — 標準
+
+優先度や release マイルストーンはラベル化されていない。会話で扱う。
+
+## 保留タスクの運用
+
+**保留・将来検討タスクは memory ではなく GitHub Issue として登録する**。これは恒久的なプロジェクト運用ルール (`feedback_deferred_tasks_as_issues` memory も参照)。
+
+triage 中に「これは v1.1.2 で検討」「デザイン要件が固まったら着手」のような保留判断をする際は:
+
+1. AskUserQuestion で「Issue 化しますか?」を提案 (default Yes)
+2. `gh issue create` で登録 (背景・判断材料・関連 PR を本文に明記)
+3. memory には書かない
+
+## 関連スキル
+
+OtetsudaiCoin 用に整備された domain skill。triage の後段で活用する:
+
+| skill | 出番 |
+| --- | --- |
+| `release-version-bump-check` | リリース PR の bump 漏れチェック / ITMS リジェクト対応 |
+| `xcstrings-bulk-update` | i18n 系 issue で xcstrings を更新する場合 |
+| `ios-simulator-app-verification` | UI バグ修正後のスクショ検証 |
+| `ios-simulator-locale-testing` | i18n 修正後の ja/en スクショ比較 |
+
+triage 中はこれらを**呼ばない**で、後段 (writing-plans / 実装フェーズ) で必要に応じて呼ぶ。
+
+## このプロジェクトの triage で特に気にすること
+
+- **App Store 連動**: バージョン / リリース系 issue は App Store の審査・承認状態と紐づく。「v1.1.1 提出済み」のような状態を確認してから着手判断する
+- **ローカライゼーション**: i18n は P0/P1/P2 で分割可能。「全部やる」より「画面別に分割」する方が PR が小さく保てる
+- **UI/UX 系**: デザイン決定待ちのものは無理にコード着手しない。要件整理ドキュメント (e.g. Figma 依頼向け) を作るところで一旦止める
+- **ITMS リジェクト**: バージョン関連の reject は緊急。triage 順序を変えて先頭に持ってくる


### PR DESCRIPTION
## 背景

セッション冒頭の「github issue を確認して対応計画を立てて」のような一行依頼に対して、汎用スキル `daily-issue-triage` が走るようになった。このスキルは「open issue 一覧 → タイプ × 規模で分類 → 並列 Explore → スコープ確認 → 後段スキルへ委譲」というメタフローを汎用的に扱うが、**OtetsudaiCoin 固有のルール** (P0/P1/P2 の意味、リリースバージョン規約、保留タスクは Issue 化、関連スキルなど) は別途定義する必要がある。

本 PR は、その固有ルールを `.kiro/steering/issue-triage-rules.md` として明示する。

## 追加ファイル

`.kiro/steering/issue-triage-rules.md` (75 行)

含まれる項目:

1. **優先度の語彙** (P0 / P1 / P2 の意味)
2. **リリースバージョン規約** (semver の運用、`RELEASE_vX.Y.Z.md` 規約)
3. **ラベル運用** (リポジトリで使われているラベル一覧)
4. **保留タスクの運用** (Issue 化、memory には書かない)
5. **関連スキル** (`release-version-bump-check` / `xcstrings-bulk-update` / `ios-simulator-app-verification` / `ios-simulator-locale-testing`)
6. **このプロジェクトの triage で特に気にすること** (App Store 連動、ローカリゼーション分割、UI/UX のデザイン決定待ち、ITMS リジェクトの優先化)

## 動作仕組み

YAML frontmatter で `inclusion: manual` を指定。常時 context には乗らず、`daily-issue-triage` スキルから手動参照される運用。これにより:

- 常時 token を消費しない
- 個人スキル (`~/.claude/skills/daily-issue-triage/`、リポジトリ外) からプロジェクト固有ロジックだけ差し込める設計
- 他プロジェクトに移っても同じ仕組みで動く

## 検証

別 subagent に「github issue を確認して対応計画を立てて」とだけ依頼したところ:

1. `daily-issue-triage` スキルが即発見・適用された
2. 本ファイルが steering として読み込まれ、**P0/P1/P2 ルール / 保留→Issue / design pending はコード着手しない** が triage 判定に反映された
3. 現在 open の 6 issue (#51 / #50 / #49 / #43 / #18 / #16) が **タイプ × 規模 + 外部ブロック** で分類された
4. AskUserQuestion の質問案が「Recommended マーカー付きで 2〜3 個」というスキル指示通りの形で提示された

## レビュー観点

1. **P0/P1/P2 の定義**が現状の運用イメージと合っているか
2. **「保留タスクは memory ではなく Issue」ルール** をプロジェクトの規範として残すことに同意するか (今日のセッション中の指示を成文化)
3. **関連スキル**として列挙したものに過不足はないか (今日 5 つの個人スキル作成済み: daily-issue-triage / release-version-bump-check / xcstrings-bulk-update / ios-simulator-app-verification / ios-simulator-locale-testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)