### PR TITLE
docs: CLAUDE.md に Git/PR 運用ルール (PR merge 確認 / 別目的混在禁止) を追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,10 @@ Note: Optional for new features or small additions. You can proceed directly to 
 6. **Keep steering current**: Run `/kiro:steering` after significant changes
 7. **Check spec compliance**: Use `/kiro:spec-status` to verify alignment
 
+## Git / PR 運用ルール
+- **feature branch に追加 commit する前**に、対応する PR が merge 済みでないかを `gh pr view <PR> --json mergedAt,state` で確認する。merge 後にローカル branch へ commit すると main に届かず、follow-up PR が必要になる。
+- **別目的の PR に無関係なファイルを同梱しない**（例: retrospective ドキュメント PR に別 issue の修正計画 plan.md を載せない）。実装対象 issue の feature branch に保管し、必要なら独立した PR を切る。
+
 ## Steering Configuration
 
 ### Current Steering Files


### PR DESCRIPTION
## Summary

前セッションの session-reflection で挙がった運用ルール 2 件を `CLAUDE.md` に反映します。

1. **feature branch に追加 commit する前に、対応する PR が merge 済みでないかを確認する**
   - `gh pr view <PR> --json mergedAt,state` で確認
   - merge 後にローカル branch へ commit すると main に届かず、follow-up PR が必要になる
2. **別目的の PR に無関係なファイルを同梱しない**
   - 例: retrospective ドキュメント PR に別 issue の修正計画 plan.md を載せない
   - 実装対象 issue の feature branch に保管し、必要なら独立した PR を切る

## 効果 (早速のドッグフーディング)

本 PR を分離した今回のセッションで、`fix/issue-54-sheet-empty-state` に乗っていた v1.1.2 bump commit を独立 PR に切り出し、CLAUDE.md 変更も独立 PR にすることで、まさに上記ルールを実例として適用しました。また `git fetch` 時に local main が origin/main より遅れていることに気付き、ルール 1 の意義を確認できました。

## Test plan

- [ ] `CLAUDE.md` を読んで Git / PR 運用ルールセクションが期待通り追加されていることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)