### PR TITLE
feat: バージョン bump の自動チェック CI を追加 (Closes #55)

### DIFF
--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -1,0 +1,34 @@
+name: Version Bump Check
+
+# project.pbxproj の MARKETING_VERSION / CURRENT_PROJECT_VERSION が
+# 前回 tag から正しく bump されているかを PR 時に検証する。
+# 詳細は scripts/version-bump-check.sh を参照。
+# ITMS-90186 / ITMS-90062 の再発防止 (issue #55)。
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+    paths:
+      - 'app/OtetsudaiCoin.xcodeproj/project.pbxproj'
+      - 'scripts/version-bump-check.sh'
+      - '.github/workflows/version-bump-check.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    name: Verify version bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tag を含む完全な履歴が必要
+
+      - name: Run version bump check
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels) }}
+        run: bash scripts/version-bump-check.sh

--- a/README.md
+++ b/README.md
@@ -223,6 +223,20 @@
 - 包括的なエラーハンドリング
 - アクセシビリティ標準への準拠
 
+### リリース運用 / バージョンバンプ CI
+
+- `app/OtetsudaiCoin.xcodeproj/project.pbxproj` の `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` を変更する PR では、GitHub Actions [`Version Bump Check`](.github/workflows/version-bump-check.yml) が起動し、前回 git tag より値が増えているかを検証する。
+- 検証ロジックの実体は [`scripts/version-bump-check.sh`](scripts/version-bump-check.sh)。ローカル実行も可能:
+
+  ```bash
+  PR_TITLE="release: v1.2.0" bash scripts/version-bump-check.sh
+  ```
+
+- 動作モード:
+  - **enforce mode**: PR タイトルが `release:` または `chore: bump` で始まる / `release` ラベルが付いた PR → bump できていない場合は CI が fail
+  - **info mode**: 上記以外 → warning のみ (検査結果はログに出るが PR は落ちない)
+- 背景: ITMS-90186 / ITMS-90062 (App Store 公開済バージョンと同じバージョン番号で再アップロード → reject) の再発防止 (issue #55)。
+
 ## ライセンス
 
 このプロジェクトは開発中のため、ライセンスは未定です。

--- a/scripts/version-bump-check.sh
+++ b/scripts/version-bump-check.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# version-bump-check.sh
+#
+# project.pbxproj の MARKETING_VERSION / CURRENT_PROJECT_VERSION が
+# 前回 git tag より増えていることを CI で検証する。
+#
+# ITMS-90186 / ITMS-90062 (App Store 公開済バージョンと同じバージョン番号で
+# 再アップロードして reject される) の再発防止。
+#
+# 環境変数:
+#   PR_TITLE   : Pull Request タイトル (release: / chore: bump で始まると enforce mode)
+#   PR_LABELS  : Pull Request labels (JSON 配列。"release" ラベルがあると enforce mode)
+#   PBXPROJ    : 検査対象 pbxproj (デフォルト: app/OtetsudaiCoin.xcodeproj/project.pbxproj)
+#   BASE_REF   : 比較対象 ref (デフォルト: 直近の tag、無ければ origin/main)
+#
+# Exit code:
+#   0: 問題なし (info / pass)
+#   1: enforce mode で違反検出
+
+set -euo pipefail
+
+PBXPROJ="${PBXPROJ:-app/OtetsudaiCoin.xcodeproj/project.pbxproj}"
+PR_TITLE="${PR_TITLE:-}"
+PR_LABELS="${PR_LABELS:-[]}"
+
+if [[ ! -f "$PBXPROJ" ]]; then
+  echo "::error::pbxproj not found: $PBXPROJ"
+  exit 1
+fi
+
+# ---- extract helpers ----
+
+# 引数で渡された ref の pbxproj から MARKETING_VERSION のユニーク値を出力。
+# ref が空の場合は working tree のファイルを読む。
+extract_marketing_version() {
+  local ref="${1:-}"
+  if [[ -z "$ref" ]]; then
+    grep -E "^[[:space:]]*MARKETING_VERSION = " "$PBXPROJ"
+  else
+    git show "${ref}:${PBXPROJ}" | grep -E "^[[:space:]]*MARKETING_VERSION = "
+  fi | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | sort -u
+}
+
+extract_build_version() {
+  local ref="${1:-}"
+  if [[ -z "$ref" ]]; then
+    grep -E "^[[:space:]]*CURRENT_PROJECT_VERSION = " "$PBXPROJ"
+  else
+    git show "${ref}:${PBXPROJ}" | grep -E "^[[:space:]]*CURRENT_PROJECT_VERSION = "
+  fi | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | sort -u
+}
+
+# semver-ish greater-than (a > b). sort -V を使った version sort で判定。
+semver_gt() {
+  local a="$1" b="$2"
+  if [[ "$a" == "$b" ]]; then
+    return 1
+  fi
+  local higher
+  higher=$(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -n 1)
+  [[ "$higher" == "$a" ]]
+}
+
+# ---- determine base ref ----
+
+if [[ -n "${BASE_REF:-}" ]]; then
+  base_ref="$BASE_REF"
+elif base_ref=$(git describe --tags --abbrev=0 2>/dev/null); then
+  :
+else
+  base_ref="origin/main"
+fi
+
+echo "Comparing against: $base_ref"
+
+# ---- read versions ----
+
+head_mv_list=$(extract_marketing_version "")
+head_bv_list=$(extract_build_version "")
+base_mv_list=$(extract_marketing_version "$base_ref" || true)
+base_bv_list=$(extract_build_version "$base_ref" || true)
+
+# 6 箇所 (本体/Tests/UITests × Debug/Release) で揺れていないか確認
+errors=0
+
+head_mv_count=$(echo "$head_mv_list" | wc -l | tr -d ' ')
+head_bv_count=$(echo "$head_bv_list" | wc -l | tr -d ' ')
+
+if [[ "$head_mv_count" -ne 1 ]]; then
+  echo "::error::project.pbxproj contains inconsistent MARKETING_VERSION values:"
+  echo "$head_mv_list" | sed 's/^/  - /'
+  errors=$((errors + 1))
+fi
+if [[ "$head_bv_count" -ne 1 ]]; then
+  echo "::error::project.pbxproj contains inconsistent CURRENT_PROJECT_VERSION values:"
+  echo "$head_bv_list" | sed 's/^/  - /'
+  errors=$((errors + 1))
+fi
+
+head_mv=$(echo "$head_mv_list" | head -n 1)
+head_bv=$(echo "$head_bv_list" | head -n 1)
+base_mv=$(echo "$base_mv_list" | head -n 1)
+base_bv=$(echo "$base_bv_list" | head -n 1)
+
+echo "HEAD : MARKETING_VERSION=$head_mv CURRENT_PROJECT_VERSION=$head_bv"
+echo "BASE : MARKETING_VERSION=$base_mv CURRENT_PROJECT_VERSION=$base_bv"
+
+# ---- detect release PR ----
+
+is_release_pr=false
+if [[ "$PR_TITLE" =~ ^(release:|chore:[[:space:]]*bump|chore:[[:space:]]*bump\ to) ]]; then
+  is_release_pr=true
+fi
+if echo "$PR_LABELS" | grep -qE '"name"[[:space:]]*:[[:space:]]*"release"'; then
+  is_release_pr=true
+fi
+
+# ---- compare ----
+
+mv_increased=false
+bv_increased=false
+
+if [[ -n "$base_mv" ]] && semver_gt "$head_mv" "$base_mv"; then
+  mv_increased=true
+fi
+if [[ -n "$base_bv" ]] && [[ "$head_bv" =~ ^[0-9]+$ ]] && [[ "$base_bv" =~ ^[0-9]+$ ]] && (( head_bv > base_bv )); then
+  bv_increased=true
+fi
+
+if $is_release_pr; then
+  echo "Mode: enforce (release PR detected)"
+  if ! $mv_increased; then
+    echo "::error::MARKETING_VERSION must be greater than base ($base_mv). Got: $head_mv"
+    errors=$((errors + 1))
+  fi
+  if ! $bv_increased; then
+    echo "::error::CURRENT_PROJECT_VERSION must be greater than base ($base_bv). Got: $head_bv"
+    errors=$((errors + 1))
+  fi
+else
+  echo "Mode: info (non-release PR)"
+  if [[ "$head_mv" != "$base_mv" ]] && ! $mv_increased; then
+    echo "::warning::MARKETING_VERSION ($head_mv) is not greater than base ($base_mv). If this is a release, add 'release' label or use 'release:' / 'chore: bump' title prefix."
+  fi
+  if [[ "$head_bv" != "$base_bv" ]] && ! $bv_increased; then
+    echo "::warning::CURRENT_PROJECT_VERSION ($head_bv) is not greater than base ($base_bv). If this is a release, mark the PR as such."
+  fi
+fi
+
+if (( errors > 0 )); then
+  echo "Version bump check failed with $errors error(s)"
+  exit 1
+fi
+
+echo "Version bump check passed"


### PR DESCRIPTION
## Summary

ITMS-90186 / ITMS-90062 (App Store 公開済バージョンと同じバージョン番号で再アップロードして reject される事象) の再発防止として、PR 時に `project.pbxproj` の `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` が前回 git tag から増えているかを自動検証する CI を追加します。

直近で 2 回 (v1.1.0→v1.1.1 / v1.1.1→v1.1.2) 同種事象が発生しており、3 度目の防止策として実装します。

## 含まれる変更

- **`scripts/version-bump-check.sh`** (156 行): 検証ロジック (bash)
  - pbxproj 内 6 箇所 (本体 / Tests / UITests × Debug / Release) で値が揃っているか
  - 前回 tag (`git describe --tags --abbrev=0`) との比較。`semver_gt` は `sort -V` で実装
  - PR タイトル `release:` / `chore: bump` または `release` ラベル付き → **enforce mode** (違反時 exit 1)
  - それ以外 → **info mode** (warning のみ、exit 0)
- **`.github/workflows/version-bump-check.yml`** (34 行): GitHub Actions workflow
  - `paths` フィルタで `app/OtetsudaiCoin.xcodeproj/project.pbxproj` 等を変更する PR のみ起動
  - `fetch-depth: 0` で tag を含む完全な履歴を取得
- **`README.md`**: 「### リリース運用 / バージョンバンプ CI」セクションを「## 開発プロセス」配下に追記

## issue #55 完了条件チェック

- [x] PR で `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` が前回タグから上がっていない場合に CI が fail
- [x] リリース PR 以外 (docs だけの PR など) では skip / info mode に落ちる仕組み
- [x] README または `RELEASE_vX.Y.Z.md` テンプレに CI 動作の説明を追記 → README に追記

## ローカル検証 (5 シナリオ)

```text
Scenario 1: PR_TITLE="fix: some bug"             → info mode, exit 0  ✅
Scenario 2: PR_TITLE="release: v1.1.2"           → enforce mode, exit 0  ✅ (1.1.2>1.1.1, 52>48)
Scenario 3: PR_TITLE="release: dummy", BASE=main → enforce mode, exit 1  ✅ (bump なしで fail)
Scenario 4: PR_LABELS=[{"name":"release"}]       → enforce mode, exit 1  ✅ (ラベルで強制)
Scenario 5: PR_LABELS=[{"name":"bug"}]           → info mode, exit 0    ✅ (非 release ラベル)
```

## 自己ドッグフード

本 PR 自身は `pbxproj` を変更していないが、`scripts/version-bump-check.sh` と `.github/workflows/version-bump-check.yml` は `paths` フィルタ対象なので、本 PR の CI でも `Version Bump Check` ジョブが起動します。タイトルが `feat:` プレフィックスのため **info mode** で動き、現 HEAD (1.1.2 / 52) > 前回タグ v1.1.1 (1.1.1 / 48) を確認するはずです。

## Test plan

- [ ] 本 PR の Actions タブで `Version Bump Check` ジョブが pass することを確認
- [ ] 次回 v1.1.x bump PR で `release:` または `chore: bump` タイトルにすると enforce mode で動くことを確認
- [ ] 万一 bump 忘れた PR を意図的に作って fail することを確認 (任意)

## 関連

- Closes #55
- Refs #60 (v1.1.2 bump で発生した直近事象), #48 (v1.1.1 bump で発生した前回事象)

🤖 Generated with [Claude Code](https://claude.com/claude-code)