### PR TITLE
chore: .gitignore に Xcode ビルド成果物と Claude Code の一時/個人ファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,12 @@ fastlane/test_output
 
 # Visual Companion (brainstorming skill) の作業ディレクトリ
 /.superpowers/
+
+# Xcode の xcodebuild 成果物 (.build/ は SwiftPM 用、こちらは app/ 配下のビルド)
+app/build/
+
+# Claude Code: session-reflection.sh が毎セッション生成する一時ファイル
+.claude/pending-reflection.md
+
+# Claude Code: 個人のローカル設定 (共有しない)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

毎セッション `git status` に出てくるノイズを排除します。

- **`app/build/`**: xcodebuild 成果物 (`.build/` は SwiftPM 用の別エントリで残置)
- **`.claude/pending-reflection.md`**: `session-reflection.sh` が毎セッション生成する振り返り候補ファイル
- **`.claude/settings.local.json`**: 個人のローカル設定 (共有しない)

なお `.claude/commands/` 配下の Spec-Driven Development コマンド定義 (`spec-init`, `spec-design`, `steering` 等) はチーム共有のため tracked のまま維持しています。

## 背景

- 直前セッションで `.claude/pending-reflection.md` の再生成や `app/build/` の出現に毎回引っかかり、commit から手動除外する手間が発生していた
- `.claude/settings.local.json` は名前から個人ローカル設定 (.local.json) なので tracked にすべきではない

## Test plan

- [ ] `git status` で 3 ファイルが untracked リストから消えていることを確認
- [ ] `.claude/commands/` 配下が引き続き tracked であることを確認 (`git ls-files .claude/` で表示される)

🤖 Generated with [Claude Code](https://claude.com/claude-code)