### PR TITLE
docs: CLAUDE.md にセッション学び 5 件を追記 (git/subagent/iOS flake/CI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,19 @@ Note: Optional for new features or small additions. You can proceed directly to 
 ## Git / PR 運用ルール
 - **feature branch に追加 commit する前**に、対応する PR が merge 済みでないかを `gh pr view <PR> --json mergedAt,state` で確認する。merge 後にローカル branch へ commit すると main に届かず、follow-up PR が必要になる。
 - **別目的の PR に無関係なファイルを同梱しない**（例: retrospective ドキュメント PR に別 issue の修正計画 plan.md を載せない）。実装対象 issue の feature branch に保管し、必要なら独立した PR を切る。
+- **push / PR 作成の直前**に `git status` で HEAD ブランチを再確認する。別ターミナル・別 Claude セッション・外部プロセスがブランチを切り替えている可能性があり、意図しないブランチへの push を防ぐ。
+- **PR 作成の前**に `gh pr list --head <branch>` で同一ブランチの既存 PR を確認する。並列セッションが先に push&PR を作っているケースがあり、二重作成や test plan 上書きを避ける。
+- **新ブランチを切る前 / feature branch を作業し直す前**に `git fetch origin` を走らせ、`origin/main` を起点にする。ローカル `main` が遅れていると古い起点でブランチを切ってしまい、後で rebase / cherry-pick の手戻りになる。
+
+## Subagent / Task 実行ルール
+- subagent の存在意義は「context 隔離」。コード変更を伴う Task は subagent、verification / test 実行のみで成果物が無い Task は main 実行でも可。subagent 接続エラー時に verification-only なら即時 main 実行へフォールバックする。
+
+## iOS テスト flake 切り分け
+- 並列 simulator run で UI テスト・load 系テストが flaky に落ちることがある。regression と断定する前に該当テストを `xcodebuild test -only-testing:` で isolated 再実行し、PASS すれば parallel flake として扱う（本修正と無関係な既知問題として切り分け可能）。
+
+## CI スクリプト開発ルール
+- bash 系 CI スクリプトは push 前にローカルで全シナリオ (pass / fail / enforce / info などのモード分岐すべて) を実行し網羅検証する。本番 GitHub Actions で初めて挙動を確認するスタイルは 1 サイクル数分 × 修正回数のロスになる。
+- リリース系の自動チェック CI は、(a) `paths` フィルタで対象ファイル変更時のみ起動、(b) PR ラベル / タイトルで enforce (失敗で blocking) と info (警告のみ) を二段階に切り替える設計にすると、false positive と CI 時間を両方抑制できる。
 
 ## Steering Configuration
 


### PR DESCRIPTION
## Summary

前回 2 セッション分の session-reflection で挙がった運用ルールを CLAUDE.md に反映するドキュメント更新です。

- **Git / PR 運用ルール** に 3 件追加 (HEAD 確認 / 既存 PR 確認 / git fetch origin)
- **Subagent / Task 実行ルール** 新節 (context 隔離目的の使い分け)
- **iOS テスト flake 切り分け** 新節 (-only-testing 単独再実行で parallel flake を判定)
- **CI スクリプト開発ルール** 新節 (ローカル全シナリオ検証 / enforce-info 二段階設計)

## 追加された運用ルールが活きた例

本 PR の作成過程そのものが学びの実演になっており、stale な \`chore/gitignore-tidy\` ブランチに誤って CLAUDE.md を編集していたところを、追加した「push 前 git status / git fetch origin」のルールに従って退避し、独立 docs PR 化しています。

## Test plan

- [x] markdownlint で diff 部分の lint pass
- [x] 既存セクションのスタイル (ハイフン箇条書き / 太字キーワード) を踏襲
- [ ] レビューで「これ実運用と合ってる？」観点の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)