### PR TITLE
fix(#56): HomeViewTests の locale 指定漏れを補う

### DIFF
--- a/app/OtetsudaiCoinTests/Presentation/Views/HomeViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Views/HomeViewTests.swift
@@ -157,9 +157,9 @@ final class HomeViewTests: XCTestCase {
         let view = HomeView(viewModel: viewModel)
 
         // バナーが表示されること
-        XCTAssertNoThrow(try view.inspect().find(text: "未支払いのお小遣いがあります"))
-        XCTAssertNoThrow(try view.inspect().find(text: "500コイン"))
-        XCTAssertNoThrow(try view.inspect().find(text: "支払い履歴を確認"))
+        XCTAssertNoThrow(try view.inspect().find(text: "未支払いのお小遣いがあります", locale: Locale(identifier: "ja")))
+        XCTAssertNoThrow(try view.inspect().find(text: "500コイン", locale: Locale(identifier: "ja")))
+        XCTAssertNoThrow(try view.inspect().find(text: "支払い履歴を確認", locale: Locale(identifier: "ja")))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

\`testHomeViewDisplaysUnpaidWarningBannerWithoutSelectedChild\` の \`ViewInspector .find(text:)\` 呼び出し 3 件に \`locale: Locale(identifier: \"ja\")\` を補完。同一スイートの他テストは既に locale 引数付きで、本テストだけ後発追加時に漏れていたものを揃えた最小修正です。

## ルートコーズ

- ViewInspector の \`find(text:)\` は \`locale:\` 未指定時に system locale で \`LocalizedStringKey\` を解決する
- CI など system locale が日本語以外の環境では、日本語リテラル \"未支払いのお小遣いがあります\" / \"500コイン\" / \"支払い履歴を確認\" がローカライズ済み文字列と不一致になり \`find\` が失敗
- 同一ファイル内の他 \`find(text:)\` 呼び出し (line 118 / 138-140 / 179) は既に \`locale: Locale(identifier: \"ja\")\` 付き → 本テスト追加時の漏れと特定

## Test plan

- [x] \`xcodebuild test -only-testing:OtetsudaiCoinTests/HomeViewTests/testHomeViewDisplaysUnpaidWarningBannerWithoutSelectedChild\` が PASS (isolated 実行)
- [x] HomeViewTests スイート全 13 件 green (regression なし確認済み)
- [ ] CI で xcodebuild test 全体実行 (LocalizationStringCatalogTests P2 範囲を除き green 想定; 後者は別 issue #53 で対応)

## 変更範囲

\`app/OtetsudaiCoinTests/Presentation/Views/HomeViewTests.swift\` 1 ファイル / 3 行のみ。

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)