### PR TITLE
feat(#53): i18n P2 - 20 件の英訳を Localizable.xcstrings に追加

### DIFF
--- a/app/OtetsudaiCoin/Resources/Localizable.xcstrings
+++ b/app/OtetsudaiCoin/Resources/Localizable.xcstrings
@@ -2,7 +2,14 @@
   "sourceLanguage" : "ja",
   "strings" : {
     "「%@」の記録を削除しますか？この操作は取り消せません。" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete the record \"%@\"? This action cannot be undone."
+          }
+        }
+      }
     },
     "%@さんの「%@」" : {
       "localizations" : {
@@ -10,6 +17,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@さんの「%2$@」"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@'s \"%@\""
           }
         }
       }
@@ -31,23 +44,64 @@
             "state" : "new",
             "value" : "%1$@のお小遣い%2$lldコインを支払いますか？"
           }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay %@'s allowance of %lld Coins?"
+          }
         }
       }
     },
     "%@のお小遣いを支払う" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay %@'s Allowance"
+          }
+        }
+      }
     },
     "%@を削除しますか？この操作は取り消せません。" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete %@? This action cannot be undone."
+          }
+        }
+      }
     },
     "%lld" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        }
+      }
     },
     "%lldコイン" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Coins"
+          }
+        }
+      }
     },
     "%lldコイン支払い" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Coins Paid"
+          }
+        }
+      }
     },
     "%lld回" : {
       "localizations" : {
@@ -60,10 +114,24 @@
       }
     },
     "+%lld" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "+%lld"
+          }
+        }
+      }
     },
     "1.0.0" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1.0.0"
+          }
+        }
+      }
     },
     "3ヶ月分サンプルデータ生成" : {
       "localizations" : {
@@ -86,7 +154,14 @@
       }
     },
     "OtetsudaiCoin" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OtetsudaiCoin"
+          }
+        }
+      }
     },
     "アプリを評価" : {
       "localizations" : {
@@ -413,7 +488,14 @@
       }
     },
     "お手伝いタスク一覧" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Help Task List"
+          }
+        }
+      }
     },
     "お手伝いでコインを貯めよう！" : {
       "localizations" : {
@@ -692,7 +774,14 @@
       }
     },
     "サンプルデータ" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sample Data"
+          }
+        }
+      }
     },
     "ストレージ容量が不足しています。デバイスの空き容量を確保してください。" : {
       "localizations" : {
@@ -815,7 +904,14 @@
       }
     },
     "チュートリアル完了です\nこれでおてつだいコインを\n始められます！" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutorial complete!\nYou're ready to start\nusing OtetsudaiCoin!"
+          }
+        }
+      }
     },
     "チュートリアル完了です。\nこれでおてつだいコインを\n始められます！" : {
       "extractionState" : "stale",
@@ -1103,7 +1199,14 @@
       }
     },
     "今月のお小遣いを支払いますか？\n金額: %lldコイン" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay this month's allowance?\nAmount: %lld Coins"
+          }
+        }
+      }
     },
     "今月のお小遣いを支払う" : {
       "localizations" : {
@@ -1230,7 +1333,14 @@
       }
     },
     "最初のお子様を\n登録しましょう" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Let's register your\nfirst child"
+          }
+        }
+      }
     },
     "最初のお子様を登録しましょう" : {
       "extractionState" : "stale",
@@ -1629,7 +1739,14 @@
       }
     },
     "更新" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update"
+          }
+        }
+      }
     },
     "月別履歴" : {
       "localizations" : {
@@ -2000,10 +2117,24 @@
       }
     },
     "追加" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
+          }
+        }
+      }
     },
     "追加分のお小遣いを支払いますか？\n金額: %lldコイン" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pay the additional allowance?\nAmount: %lld Coins"
+          }
+        }
+      }
     },
     "追加分を支払う" : {
       "localizations" : {
@@ -2078,7 +2209,14 @@
       }
     },
     "選択した期間にお手伝いの記録がありません。\n記録タブから新しいお手伝いを記録してみましょう！" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No chore records for the selected period.\nTry recording a new chore from the Record tab!"
+          }
+        }
+      }
     },
     "選択中" : {
       "localizations" : {


### PR DESCRIPTION
## Summary

\`LocalizationStringCatalogTests/testAllKeysHaveEnglishTranslation\` で
失敗していた P2 範囲のキー 20 件に英訳を補完しました。

### カテゴリ別内訳

1. **アラート / 確認ダイアログ本文 (5 件)** — 削除確認・支払い確認
2. **数値プレースホルダ系 (4 件)** — \`%lld\` / \`%lldコイン\` / \`%lldコイン支払い\` / \`+%lld\`
3. **ブランド / バージョン (2 件)** — \`OtetsudaiCoin\` / \`1.0.0\` (英語でも同一値)
4. **その他 UI (9 件)** — Section header / Button label / 空状態メッセージ等

### スタイル整合性

v1.1.1 (#47) で確立された既存翻訳に揃えました:

- Title Case for buttons/labels: \`Update\` / \`Add\` / \`Pay %@'s Allowance\`
- Sentence case for full sentences: \`Pay this month's allowance?\`
- \`OtetsudaiCoin\` ブランド名はスペースなしで維持
- ASCII クォート \`\"...\"\` を使用 (英語圏で全角 \`「」\` 不要)
- 既存類似キー \`チュートリアル完了です。\\n...\` (\`。\` 付き) の en 訳に合わせて
  \`Tutorial complete!\\nYou're ready to start\\nusing OtetsudaiCoin!\` を採用

### スコープ外メモ

元 issue が言及していた「HelpTask のデフォルト値」は \`SampleDataService\` の
raw Swift 文字列 (\`お風呂掃除\` 等) で xcstrings 経由ではないため対象外です。
必要なら別 issue で HelpTask データシード自体の i18n 化を検討してください。

## Verification

- [x] xcstrings diff: **+156/-18 行 (~8 行/key)** — Xcode フォーマット保持 (\`\" : \"\` セパレータ / 空 dict 形式維持)
- [x] \`LocalizationStringCatalogTests\` 全 13 件 green
  - \`testAllKeysHaveEnglishTranslation\` ✅
  - \`testEnglishTranslationsAreMarkedAsTranslated\` ✅
  - \`testEnglishTranslationsAreNotJapanese\` ✅ (プレースホルダ stripping 後の日本語チェック)
- [x] 既存翻訳の上書きなし (script 出力で \`preserved: 0\`、新規 fill のみ \`filled_in: 20\`)

## Test plan

- [x] LocalizationStringCatalogTests スイート単独で green 確認 (\`iPhone 17\` simulator)
- [ ] CI で xcodebuild test 全体実行 (HomeViewTests locale 修正は #67 で別 PR、これと独立)
- [ ] 英語ロケールで実機/シミュレータ確認 (任意 — 翻訳品質チェック)

## 関連

- 親 issue (P0/P1 完了済み): #43
- 直近の i18n PR: #47
- HomeViewTests locale 修正: PR #67 (#56 対応、並走中)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)