### PR TITLE
docs: append session-reflection learnings to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,13 @@ Note: Optional for new features or small additions. You can proceed directly to 
 - bash 系 CI スクリプトは push 前にローカルで全シナリオ (pass / fail / enforce / info などのモード分岐すべて) を実行し網羅検証する。本番 GitHub Actions で初めて挙動を確認するスタイルは 1 サイクル数分 × 修正回数のロスになる。
 - リリース系の自動チェック CI は、(a) `paths` フィルタで対象ファイル変更時のみ起動、(b) PR ラベル / タイトルで enforce (失敗で blocking) と info (警告のみ) を二段階に切り替える設計にすると、false positive と CI 時間を両方抑制できる。
 
+## Spec / Plan 作成ルール
+- spec / design ドキュメント作成時にも前提となる既存コードを実際に Read で開いて verify する。writing-plans 段階で初めて View 階層など実装差分が判明すると spec 修正に手戻りが発生する。spec 段階で View 階層・主要関数の実装を 1 回 Read してから書き起こす。
+- Plan からの「既存 convention に合わせるための設計改善的逸脱」は、その場で commit メッセージに deviation 理由を明記して反映する（例: 新規 `XxxViewTests.swift` を作る計画を既存 `BannerAdViewTests.swift` 等に揃える）。事前に plan を rewrite しない（時間ロス）、事後に黙って逸脱しない（レビュー時に混乱）。
+
+## プロジェクト固有制約 (Xcode 16+)
+- このプロジェクトの Xcode project は `PBXFileSystemSynchronizedRootGroup` を採用しているため、新規 `.swift` を所定ディレクトリに置くだけで自動認識され `project.pbxproj` 編集は不要。Plan 作成や Task 見積もりで「pbxproj 編集ステップ」を blocker 扱いしない。
+
 ## Steering Configuration
 
 ### Current Steering Files


### PR DESCRIPTION
## Summary

前回セッション (#49 RecordView バナー対応) の `session-reflection.sh` が生成した振り返り候補 2 件を CLAUDE.md に追加します。

- **Spec / Plan 作成ルール**: spec / design 段階で前提となる既存コードを Read で verify する / Plan からの設計改善的逸脱は commit メッセージに deviation 理由を明記する
- **プロジェクト固有制約 (Xcode 16+)**: `PBXFileSystemSynchronizedRootGroup` 採用のため `.swift` 追加で `project.pbxproj` 編集不要、Task 見積もりで blocker 扱いしない

CLAUDE.md ルール「別目的の PR に無関係なファイルを同梱しない」に従い、issue 実装と分離した独立 docs PR として切り出しています。

## Test plan

- [x] `CLAUDE.md` 差分が反映 2 件のみで他ファイル変更なし
- [x] markdown lint 通過 (MD031/032/040/060/029)
- [ ] reviewer 確認後 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)