### PR TITLE
docs: 振り返り (TDD red skip 条件 + reload trigger 集約) を CLAUDE.md に追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ Note: Optional for new features or small additions. You can proceed directly to 
 - Plan からの「既存 convention に合わせるための設計改善的逸脱」は、その場で commit メッセージに deviation 理由を明記して反映する（例: 新規 `XxxViewTests.swift` を作る計画を既存 `BannerAdViewTests.swift` 等に揃える）。事前に plan を rewrite しない（時間ロス）、事後に黙って逸脱しない（レビュー時に混乱）。
 - spec 作成時のテストファイル存在確認は、`ls Presentation/ViewModels/` のような浅い listing ではなく `find . -name "X*Tests.swift" -not -path "*build*"` で全階層から探す。サブディレクトリ前提で見落とすと spec の前提が崩れて自己修正 commit が必要になる。
 - **Plan 実行中の user 応答による deviation の取り扱い**: writing-plans 中の AskUserQuestion で plan を reverse / scope 縮小した場合 (例: BannerAdView 移動 → 維持、追加 test 3 件 → 1 件)、plan 本体も書き換えた上で PR description の `## Plan からの逸脱` 節に deviation 理由を明記する。reviewer が「なぜ plan と差分があるのか」を追えるようにすると、レビュー時の混乱を防げる。
+- **TDD の red verification step skip 条件**: red 段階の `xcodebuild test` 実行を skip 可能なのは、(a) コンパイルエラー確定 (型 / メソッド未定義で `BUILD FAILED` 必至)、(b) 直接的な期待値差 (`XCTAssertEqual` の数値ずれが impl 不在で必ず起きる) の場合のみ。skip した場合は commit メッセージと PR description の `## Plan からの逸脱` に skip 理由を明記して reviewer が追えるようにする。behavioral edge case (observer 経路、race condition、`setLoading` 副作用などタイミング依存) を試す red は **必ず実行** して fail を確認する。スキップすると「green になったが期待した経路ではなかった」を見逃す。
 
 ## プロジェクト固有制約 (Xcode 16+)
 - このプロジェクトの Xcode project は `PBXFileSystemSynchronizedRootGroup` を採用しているため、新規 `.swift` を所定ディレクトリに置くだけで自動認識され `project.pbxproj` 編集は不要。Plan 作成や Task 見積もりで「pbxproj 編集ステップ」を blocker 扱いしない。
@@ -98,6 +99,7 @@ Note: Optional for new features or small additions. You can proceed directly to 
 - `NotificationManager.shared.notifyHelpRecordUpdated()` (および類似の data-update 通知) を呼ぶと、observer 側で `loadData()` → `setLoading(true)` が走り、その副作用で `errorMessage` がクリアされる (`BaseViewModel.setLoading` の挙動: `if loading { errorMessage = nil }`)。
 - このため write 操作が **0 件しか成功しなかった場合に notify を呼ぶと、直前に `setError(...)` でセットした errorMessage が消えてしまう**。write が 1 件以上成功したときだけ notify する設計にする (`if !successIds.isEmpty { notify() }`)。
 - `successMessage` は `setLoading(true)` で消えないので、success のみ気にする既存パターン (`recordHelp` 等) では問題化しなかった。一括 / batch 系の新規実装で踏みやすい罠。
+- **reload trigger は data-lifecycle の入り口に集約する**: read-only な derived state (counts, summaries 等) を新規追加する場合、reload trigger は `loadData` 末尾 / `selectXxx` 末尾 / 依存値の `onChange` / 既存 `notifyXxxUpdated` observer 経路 にだけ置く。`recordXxx` / `recordBulkXxx` などの write 操作内で直接 reload を呼ばない。reload を 1 経路に統一することで、上記の `setLoading(true)` による errorMessage クリアの罠を踏まず、同一データの重複 fetch も避けられる (#73 で確立)。
 
 ## Steering Configuration
 


### PR DESCRIPTION
## Summary

前回セッションの振り返り (`.claude/pending-reflection.md` で提示された 2 件) を CLAUDE.md に統合する小さな docs 変更。

- **Spec / Plan 作成ルール** セクションに **TDD の red verification step skip 条件** を追加。red の `xcodebuild test` 実行を skip 可能なのは (a) コンパイルエラー確定、(b) 期待値差確定 の 2 ケースに限定し、behavioral edge case (observer 経路 / race condition / `setLoading` 副作用) は必ず実行する原則を明文化。
- **NotificationManager 発火と error message の干渉** セクションに **reload trigger は data-lifecycle の入り口に集約する** ルールを追加。新規 derived state (counts, summaries) の reload は `loadData` 末尾 / `selectXxx` 末尾 / `onChange` / 既存 `notifyXxxUpdated` observer に置き、`recordXxx` / `recordBulkXxx` write 操作内で直接 reload を呼ばない原則 (#73 で確立) を明文化。

`.claude/pending-reflection.md` は本 commit に含めず別途削除済み (untracked)。

## Plan からの逸脱

なし (SessionStart hook の承認内容そのまま反映)。

## Test plan

- [x] CLAUDE.md diff が ±2 行で他に影響なし
- [x] 該当セクション (Spec / Plan 作成ルール、NotificationManager) の既存箇条書きと書式整合

🤖 Generated with [Claude Code](https://claude.com/claude-code)