### PR TITLE
docs(#50): ASC English localization draft for v1.1.1 (Phase 1)

### DIFF
--- a/RELEASE_v1.1.1_ASC_EN.md
+++ b/RELEASE_v1.1.1_ASC_EN.md
@@ -1,0 +1,169 @@
+# おてつだいコイン v1.1.1 — App Store Connect English Localization Draft
+
+This document collects the **English-locale text drafts** for the v1.1.1 ASC listing (Issue [#50](https://github.com/es0612/OtetsudaiCoin/issues/50) Phase 1). All copy is **draft only** — author/PO should spot-review and adjust tone before pasting into ASC.
+
+- **Target audience (per #50 decision, 2026-05-23)**: Japanese-speaking families abroad / bilingual households. The app's currency is fixed to ¥ (JPY), so the English copy intentionally signals "Japanese-speaking household tool" rather than positioning as a generic English-market chores app.
+- **Ship gate**: App build is unaffected; only ASC localization metadata is added. The English locale can be saved on ASC without resubmitting v1.1.1.
+- **Scope**: Sections 1.2 / 1.3 / 1.4 / 1.6 from #50 Phase 1, plus App Name / Subtitle that ASC requires when adding a new locale. Section 1.5 (English-locale screenshots) is deferred to a follow-up using [[ios-simulator-locale-testing]].
+
+## 1. App Name (アプリ名)
+
+ASC field: **App Name** — up to 30 characters. Required when adding a new locale.
+
+```text
+Otetsudai Coin
+```
+
+Character count: **14 chars** (within 30). 16 chars headroom.
+
+### Notes / review points
+
+- Keeps the romanized product name. Matches "Otetsudai Coin" used throughout the Description and What's New copy below.
+- Alternative options if the PO prefers a more descriptive name:
+  - `Otetsudai Coin: Family Chores` (29 chars) — explicit category hint
+  - `OtetsudaiCoin` (13 chars) — matches the Bundle ID style (`com.asapapalab.OtetsudaiCoin`)
+- Decision should be **made before pasting** because Apple makes App Name changes painful (requires new version submission to alter).
+
+## 2. Subtitle (サブタイトル)
+
+Source: Japanese subtitle `子どもとつくる、お手伝い習慣` (RELEASE_v1.1.1.md § 1.3).
+
+ASC field: **Subtitle** — up to 30 characters. Required when adding a new locale.
+
+```text
+Build chore habits with kids
+```
+
+Character count: **28 chars** (within 30). 2 chars headroom.
+
+### Notes / review points
+
+- Mirrors the action-oriented framing of the Japanese ("つくる" → "Build") and the inclusivity of the relationship ("子どもとつくる" → "with kids").
+- Alternative subtitles, all within 30 chars:
+  - `Family chores, made together` (28) — emphasizes family
+  - `Track chores, build allowance` (29) — emphasizes the allowance loop
+  - `Chores & allowance for kids` (27) — most descriptive, least emotive
+- "kids" is plural intentionally; the app supports multiple children.
+
+## 3. Description (説明文)
+
+Source: Japanese version in `RELEASE_v1.1.0.md` § 2.3 (still current for v1.1.1).
+
+ASC field: **Description** — up to 4000 characters.
+
+```text
+A fun way to support your child's chores at home — together as a family.
+
+[Main features]
+✅ Record chores with a single tap and earn coins
+✅ Register multiple children, each with a personal theme color
+✅ Customize the list of chores to match your home
+✅ Monthly history view with automatic allowance calculation
+✅ Monthly Retrospective screen — celebrate effort as a family
+✅ Backdate entries when you forget to log right away
+
+[What makes it different]
+🎯 Simple, child-friendly design
+🏆 Coin animations and sound effects to keep kids motivated
+📱 Fully offline — no internet connection required
+🔒 All data stays on your device only
+
+Note for international users:
+Otetsudai Coin is designed primarily for Japanese-speaking families.
+The user interface is available in English, but the allowance amount
+is displayed in Japanese yen (¥) only. The app is well suited for
+Japanese families living abroad and bilingual households who want to
+maintain a Japanese-style chores-and-allowance routine.
+
+Help your child build great habits and bring your family closer — one chore at a time!
+```
+
+### Notes / review points
+
+- **Currency disclosure** is placed near the end so the value props land first. Trade-off: moving it to the top reduces "wrong-currency" review complaints but pushes the value props down. PO call.
+- Uses the App Name decided in § 1 (`Otetsudai Coin`). Swap if § 1 changes.
+- Emojis are kept — the Japanese listing uses them and they render fine in both locales.
+
+## 4. Keywords (キーワード)
+
+Source: Japanese keywords `おてつだい,お小遣い,記録,子供,家事,習慣,しつけ,家族` (RELEASE_v1.1.1.md § 1.3).
+
+ASC field: **Keywords** — up to 100 characters, comma-separated, **no spaces after commas** (ASC strips them anyway — packing more keywords).
+
+```text
+chores,allowance,kids,family,habit,routine,Japanese,bilingual,record,parenting
+```
+
+Character count: **78 chars** (within 100). 22 chars headroom.
+
+### Notes / review points
+
+- App name "Otetsudai Coin" is auto-indexed by Apple — **do not** include it as a keyword (waste of slot).
+- `Japanese` + `bilingual` deliberately signal the target audience (per #50 decision: in-search hits from Japanese-speaking families abroad searching for "Japanese chores app" or "bilingual household").
+- `parenting` is the broadest catch-all; could be dropped for `homeschool` if homeschool families are a known segment.
+- Avoid trademark keywords (e.g. competitors' app names).
+
+## 5. Promotional Text (プロモーションテキスト)
+
+Source: Japanese v1.1.1 promo (RELEASE_v1.1.1.md § 2.2).
+
+ASC field: **Promotional Text** — up to 170 characters. Editable after submission without re-review.
+
+```text
+Stable home screen + English UI support. A great fit for Japanese-speaking families abroad and bilingual households building chores-and-allowance habits together.
+```
+
+Character count: **162 chars** (within 170). 8 chars headroom.
+
+### Notes / review points
+
+- Front-loads the v1.1.1 value props ("stable home screen + English UI") so existing users see the update reason in the App Store update tab.
+- Mirrors the Japanese tone of "海外暮らしのご家族や英語で育児するご家庭でも" by spelling out the target families explicitly.
+
+## 6. What's New for v1.1.1 (このバージョンの新機能)
+
+Source: Japanese **Draft A — emoji-friendly version** from RELEASE_v1.1.1.md § 2.1.
+
+ASC field: **What's New in This Version** — up to 4000 characters. The first ~170 characters show in the App Store update tab before the "more" toggle, so the value summary is up top.
+
+```text
+Version 1.1.1 brings a more stable home screen and improved English support ✨
+
+🐛 Bug fixes
+- Fixed an issue where your children's cards and stats sometimes failed to appear the first time the Home screen opened.
+- Fixed the "Version" row on the Settings screen so it now shows the current version (1.1.1) correctly instead of an outdated number.
+
+🌍 Improved English support
+- Tab labels (Home / Record / Settings), the Retrospective screen, each section of the Settings screen, notification settings, and the body text of reminder notifications now display naturally in English.
+
+Thank you for using Otetsudai Coin — we hope you keep enjoying it together with your family!
+```
+
+Leading summary line is **77 chars** — fits comfortably in the App Store "before more" window (~170 chars).
+
+### Notes / review points
+
+- "Improved English support" keeps the same emoji and ordering as the Japanese version (🐛 then 🌍), so the update note feels parallel across locales.
+- Mentioning `1.1.1` in the Settings bug fix mirrors the Japanese text and helps users verify after updating.
+- For v1.1.2 onward, follow the **Phase 2** pattern in #50: append a `## What's New (English)` section to the new `RELEASE_v1.1.2.md` and run the same draft → spot-review → ASC paste flow.
+
+## 7. ASC paste-in checklist (Phase 1 wrap-up)
+
+This is the work the **author/PO must do in the ASC UI** to finish Phase 1 (#50 § 1.1, 1.7).
+
+- [ ] ASC → My Apps → おてつだいコイン → Localizations → **Add Language: English (U.S.)**
+- [ ] Paste § 1 (App Name) into the new English locale
+- [ ] Paste § 2 (Subtitle) into the new English locale
+- [ ] Paste § 3 (Description) into the new English locale
+- [ ] Paste § 4 (Keywords) into the new English locale
+- [ ] Paste § 5 (Promotional Text) into the new English locale
+- [ ] Paste § 6 (What's New for v1.1.1) into the new English locale
+- [ ] Save the English locale (no version resubmission needed — locale add is metadata)
+- [ ] (Deferred) Capture English-locale screenshots and upload — track in a v1.1.x follow-up using [[ios-simulator-locale-testing]]
+
+## 8. Related
+
+- Issue: [#50](https://github.com/es0612/OtetsudaiCoin/issues/50)
+- Source Japanese drafts: [`RELEASE_v1.1.1.md`](./RELEASE_v1.1.1.md) § 1.3 / § 2.1 / § 2.2 / § 2.3
+- Skill: [[ios-simulator-locale-testing]] (for § 1.5 screenshot deferred task)
+- Future integration: Phase 2 of #50 — incorporate the English What's New draft step into `RELEASE_v1.1.2.md` and subsequent release docs.


### PR DESCRIPTION
## Summary

Issue #50 Phase 1 (英語ストア掲載文の追加、2026-05-23 決定確定) の AI 分担範囲を draft 化。新規ファイル `RELEASE_v1.1.1_ASC_EN.md` に App Store Connect 英語ロケーション用の copy を一括ドキュメント化した。

- §1.2 説明文 / §1.3 キーワード / §1.4 プロモーションテキスト / §1.6 What's New 英訳 draft
- ASC で新規ロケール追加時に required になる **App Name / Subtitle** も追加
- §1.5 英語ロケール用スクショは本 PR スコープ外 (deferred: `ios-simulator-locale-testing` skill で別 PR)
- ターゲットは **在外日本人 / バイリンガル家庭** (¥ 通貨制約を受け入れる #50 決定に準拠)
- UI 用語は実 xcstrings (\`app/OtetsudaiCoin/Resources/Localizable.xcstrings\`) と一致確認済み — 「月の振り返り画面」は実装側で \`Retrospective\` となっているのでそれに揃えた

## 要 PO 判断 (paste 前)

ドキュメント本体に default + 代替案を併記したが、PO が確定すべき項目:

| Section | Default (採用案) | 代替案 |
|---------|------------------|--------|
| §1 App Name | \`Otetsudai Coin\` (14) | \`Otetsudai Coin: Family Chores\` (29) / \`OtetsudaiCoin\` (13) |
| §2 Subtitle | \`Build chore habits with kids\` (28) | \`Family chores, made together\` (28) / \`Track chores, build allowance\` (29) / \`Chores & allowance for kids\` (27) |
| §3 Description | currency disclosure を末尾配置 | 冒頭 200 char に移動 (誤購入クレーム予防的) |

## 文字数チェック (実測)

- App Name: 14 / 30 chars
- Subtitle: 28 / 30 chars
- Keywords: 78 / 100 chars
- Promotional Text: 162 / 170 chars
- What's New 先頭サマリ行: 77 / ~170 chars (App Store "more" 前の表示枠)

## 次のステップ (本 PR スコープ外)

- [ ] PO 判断項目を確定 → ドキュメントを update (本 PR の review コメントで指定 → follow-up commit でも、merge 後の separate PR でも可)
- [ ] §7 paste-in checklist の手順で PO が ASC UI 操作 (アプリビルド非依存、locale add は metadata 扱いなので v1.1.1 再提出不要)
- [ ] §1.5 英語ロケール用スクショ撮影 (別 PR)
- [ ] Phase 2: v1.1.2 以降のリリース手順への組み込み (#50 § Phase 2)

## Test plan

- [x] xcstrings の en 訳と What's New / Description の UI 用語整合性を確認 (\`振り返り\` → \`Retrospective\`、\`Home/Record/Settings\` 等)
- [x] 全 char count を実測 (App Name/Subtitle/Keywords/Promotional Text)
- [x] 並行 PR (CLAUDE.md/RELEASE in:title) が無いことを確認
- [ ] PO の spot-review 完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #50