### PR TITLE
fix(#90): PersistenceController.shared を nonisolated 化し Swift 6 actor 分離警告 3 件を解消

### DIFF
--- a/app/OtetsudaiCoin/Persistence.swift
+++ b/app/OtetsudaiCoin/Persistence.swift
@@ -27,12 +27,21 @@ enum PersistenceError: LocalizedError {
 
 @MainActor
 struct PersistenceController {
-    static let shared = PersistenceController()
-    
-    private static let logger = Logger(subsystem: "com.asapapalab.OtetsudaiCoin", category: "CoreData")
-    
+    // `shared` を @MainActor 隔離のままにすると nonisolated な init の default 引数
+    // (`persistenceController: PersistenceController = .shared`) から同期参照できず
+    // "main actor-isolated static property 'shared' can not be referenced from a
+    // nonisolated context" 警告 (Swift 6 では error) を 3 つの CoreData リポジトリで出す。
+    // 型は @MainActor 由来で Sendable なので `shared` を nonisolated 化すれば解消できる
+    // (compiler も "nonisolated(unsafe) is unnecessary for Sendable type" と指摘)。
+    // それには init を nonisolated 化する必要があり、init が参照する logger / errorPublisher
+    // も併せて隔離解除する (logger=Sendable で平 nonisolated、errorPublisher=非Sendable で
+    // nonisolated(unsafe))。いずれも単一インスタンスの不変 `let` で挙動は不変 (#90)。
+    nonisolated static let shared = PersistenceController()
+
+    private nonisolated static let logger = Logger(subsystem: "com.asapapalab.OtetsudaiCoin", category: "CoreData")
+
     /// 永続化エラーを通知するPublisher
-    static let errorPublisher = PassthroughSubject<PersistenceError, Never>()
+    nonisolated(unsafe) static let errorPublisher = PassthroughSubject<PersistenceError, Never>()
 
     static let preview: PersistenceController = {
         let result = PersistenceController(inMemory: true)
@@ -53,7 +62,7 @@ struct PersistenceController {
 
     let container: NSPersistentContainer
 
-    init(inMemory: Bool = false) {
+    nonisolated init(inMemory: Bool = false) {
         container = NSPersistentContainer(name: "OtetsudaiCoin")
         if inMemory {
             guard let storeDescription = container.persistentStoreDescriptions.first else {


### PR DESCRIPTION
Closes #90

## Summary

XcodeCloud のアーカイブログに出ていた **Swift 6 actor 分離警告 3 件** を解消します。

```
main actor-isolated static property 'shared' can not be referenced from a
nonisolated context; this is an error in the Swift 6 language mode
```

| ファイル | 行 | クラスの隔離 | 原因 |
|---|---|---|---|
| CoreDataChildRepository.swift | 9 | `@MainActor` | SE-0411 (default value 式が nonisolated で評価される隙間) |
| CoreDataHelpRecordRepository.swift | 9 | `@MainActor` | 同上 |
| CoreDataHelpTaskRepository.swift | 8 | 非分離 (background context 使用) | 純粋な nonisolated 参照 |

いずれも init の default 引数 `persistenceController: PersistenceController = .shared` が、`@MainActor` 隔離された `PersistenceController.shared` を nonisolated 文脈から同期参照していたのが原因です。

## 修正方針

`PersistenceController` は `@MainActor struct` で**既に Sendable**（global-actor 隔離型は暗黙 Sendable）なので、`shared` の隔離を外せば nonisolated 文脈から参照可能になります。コンパイラも `nonisolated(unsafe) is unnecessary for a constant with 'Sendable' type` と平 `nonisolated` を示唆しました。

`shared` を nonisolated 化するにはその初期化式が呼ぶ `init` も nonisolated 化が必要で、init が参照する static も併せて隔離解除しました（**Persistence.swift 1 ファイル完結、リポジトリ側は無変更**）:

- `nonisolated static let shared` — 型が Sendable なので平 nonisolated（`unsafe` 不要）
- `nonisolated init(inMemory:)` — shared の初期化を nonisolated 文脈から実行可能に
- `private nonisolated static let logger` — `Logger` は Sendable
- `nonisolated(unsafe) static let errorPublisher` — `PassthroughSubject` は非 Sendable のため unsafe が適切

いずれも**単一インスタンスの不変 `let`** で初期化 race は `swift_once` が保証するため、ランタイム挙動は不変です。

### 別案を採らなかった理由

- **デフォルト引数 `= .shared` 撤去**: 呼び出し元が **~30 箇所**（RepositoryFactory / 各 View）全て `= .shared` デフォルトに依存しており blast radius 過大。
- **型から `@MainActor` を外す**: `errorPublisher`（PassthroughSubject 非Sendable）・`saveContext` の viewContext main-thread 保証が崩れる。`@MainActor` は viewContext 安全性で load-bearing なため維持。
- **upcoming feature `IsolatedDefaultValues`**: `@MainActor` の 2 クラスは直るが、非分離の HelpTaskRepository は直らず 3 件中 1 件が残る。

## Test plan

警告（コンパイラ診断）の修正のため behavioral unit test は追加せず、**警告再現 → 消滅 + suite green** で担保しています。

- [x] **red**: 素の `xcodebuild build`（minimal concurrency / Swift 5 mode）で 3 警告を再現 — XcodeCloud ログと完全一致
- [x] **green**: 同条件で 3 警告消滅・新規 warning/error **ゼロ**（ビルド全体の warning 数 3→0）・`** BUILD SUCCEEDED **`
- [x] **regression**: `CoreDataChildRepositoryTests` 4/4 passed（save/findById/findAll/update/delete）

🤖 Generated with [Claude Code](https://claude.com/claude-code)