### PR TITLE
refactor(#104): 購読者ゼロの PersistenceController.errorPublisher を削除

### DIFF
--- a/app/OtetsudaiCoin/Persistence.swift
+++ b/app/OtetsudaiCoin/Persistence.swift
@@ -8,7 +8,6 @@
 
 import CoreData
 import os.log
-import Combine
 
 /// Core Dataの永続化エラー
 enum PersistenceError: LocalizedError {
@@ -33,15 +32,12 @@ struct PersistenceController {
     // nonisolated context" 警告 (Swift 6 では error) を 3 つの CoreData リポジトリで出す。
     // 型は @MainActor 由来で Sendable なので `shared` を nonisolated 化すれば解消できる
     // (compiler も "nonisolated(unsafe) is unnecessary for Sendable type" と指摘)。
-    // それには init を nonisolated 化する必要があり、init が参照する logger / errorPublisher
-    // も併せて隔離解除する (logger=Sendable で平 nonisolated、errorPublisher=非Sendable で
-    // nonisolated(unsafe))。いずれも単一インスタンスの不変 `let` で挙動は不変 (#90)。
+    // それには init を nonisolated 化する必要があり、init が参照する logger も併せて
+    // 隔離解除する (logger=Sendable で平 nonisolated)。いずれも単一インスタンスの不変
+    // `let` で挙動は不変 (#90)。
     nonisolated static let shared = PersistenceController()
 
     private nonisolated static let logger = Logger(subsystem: "com.asapapalab.OtetsudaiCoin", category: "CoreData")
-
-    /// 永続化エラーを通知するPublisher
-    nonisolated(unsafe) static let errorPublisher = PassthroughSubject<PersistenceError, Never>()
 
     static let preview: PersistenceController = {
         let result = PersistenceController(inMemory: true)
@@ -67,7 +63,6 @@ struct PersistenceController {
         if inMemory {
             guard let storeDescription = container.persistentStoreDescriptions.first else {
                 Self.logger.error("永続ストア記述子が見つかりません")
-                Self.errorPublisher.send(.storeLoadingFailed(NSError(domain: "PersistenceController", code: -1, userInfo: [NSLocalizedDescriptionKey: "永続ストア記述子が見つかりません"])))
                 return
             }
             storeDescription.url = URL(fileURLWithPath: "/dev/null")
@@ -76,10 +71,7 @@ struct PersistenceController {
             if let error = error {
                 // エラーログの出力
                 Self.logger.error("Core Dataストアの読み込みに失敗しました: \(error.localizedDescription)")
-                
-                // エラーを通知
-                Self.errorPublisher.send(.storeLoadingFailed(error))
-                
+
                 /*
                  本番環境では以下のような対応を検討:
                  * ストアファイルの削除と再作成
@@ -111,7 +103,6 @@ struct PersistenceController {
                 try context.save()
             } catch {
                 Self.logger.error("コンテキストの保存に失敗しました: \(error.localizedDescription)")
-                Self.errorPublisher.send(.contextSaveFailed(error))
                 throw PersistenceError.contextSaveFailed(error)
             }
         }


### PR DESCRIPTION
## 概要

`PersistenceController.errorPublisher` (`PassthroughSubject<PersistenceError, Never>`) は **`.send` する側しか存在せず、`.sink`/`.subscribe` する購読者がコードベースに 1 つも無い** dead-ish code でした (#90 作業中に発見、Issue #104)。永続化エラーは併設の `logger.error(...)` でのみ通知されていたため、`errorPublisher` を削除して `logger.error` に集約します。

`grep -rn "errorPublisher" app/ --include="*.swift"` → 宣言 + `.send` 3 箇所のみ (購読者 0)。

## 変更内容

- `nonisolated(unsafe) static let errorPublisher` 宣言を削除
- 3 箇所の `Self.errorPublisher.send(...)` を削除 (inMemory guard / loadPersistentStores 失敗 / saveContext 失敗)
- 不要になった `import Combine` を削除
- `#90` の nonisolated 化解説コメントから errorPublisher の記述を除去
- **各エラーパスの `logger.error(...)` は維持** → error がログに届く挙動は不変
- `PersistenceError` enum と `.storeLoadingFailed` / `.contextSaveFailed` 両 case は **維持** (`LocalizedMessageTests` / `LocalizationStringCatalogTests` / `ErrorMessageConverter` が参照中のため)

## テスト

`xcodebuild test -scheme OtetsudaiCoin -only-testing:OtetsudaiCoinTests` (iPhone 17 Pro):

- 本変更で**コンパイル成功** (errorPublisher 参照は他に無し)、新規 test 失敗ゼロ
- ⚠️ `TaskCardViewTests.test_existingCountRow_visible_whenCountIsOne/Many` の 2 件が失敗するが、**これは本 PR と無関係な既存失敗**:
  - 失敗理由: `ViewSearch.swift:399: "Search did not find a match. Possible blockers: AccessibilityImageLabel x3"` (ViewInspector が `TaskCardView` の `Image(systemName:)` を traverse できない既知制約、CLAUDE.md 記載)
  - **clean main (`b46af8f`) でも同一 2 件が同じ理由で失敗する**ことを isolated 実行で確認済み (本変更は `Persistence.swift` のみ変更、`TaskCardView` 非依存)
  - 別 issue で test 側の回避策 (`find(ViewType.Text.self)` 経由) を追跡

## 関連

- Issue #104
- 発見元: PR #103 (#90 fix)