### PR TITLE
test(#106): TaskCardViewTests を findAll(Text) 化し AccessibilityImageLabel blocker を回避

### DIFF
--- a/app/OtetsudaiCoinTests/Presentation/Components/TaskCardViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/TaskCardViewTests.swift
@@ -10,6 +10,23 @@ final class TaskCardViewTests: XCTestCase {
         HelpTask(id: UUID(), name: name, isActive: true, coinRate: coinRate)
     }
 
+    /// TaskCardView 内の全 Text を列挙して文字列で返す。
+    ///
+    /// `find(viewWithAccessibilityIdentifier: "existing_count_label")` は
+    /// `Image(systemName:)` × 3 (taskIcon / existingCountRow / selectionIndicator) が
+    /// `AccessibilityImageLabel` blocker となり該当 Text へ到達できない
+    /// (CLAUDE.md「SwiftUI View テスト戦略 § AccessibilityImageLabel blocker」)。
+    /// `findAll(ViewType.Text.self)` は blocker を跨いで Text を収集できるためこちらを使う。
+    private func renderedTexts(existingCount: Int) throws -> [String] {
+        let view = TaskCardView(
+            task: makeTask(),
+            isSelected: false,
+            existingCount: existingCount,
+            onTap: {}
+        )
+        return try view.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+    }
+
     // MARK: - #73 existingCountRow
 
     func test_existingCountRow_hidden_whenCountIsZero() throws {
@@ -24,26 +41,23 @@ final class TaskCardViewTests: XCTestCase {
     }
 
     func test_existingCountRow_visible_whenCountIsOne() throws {
-        let view = TaskCardView(
-            task: makeTask(),
-            isSelected: false,
-            existingCount: 1,
-            onTap: {}
+        // coinInfo "10コイン" が "1" を含むため `contains("1")` だけだと
+        // existingCountRow が無くても通る false positive になる。
+        // coinInfo は常に "...コイン" suffix なので除外し、それ以外の Text に
+        // count 数字が現れることで existingCountRow の描画を確認する。
+        // 文言を exact match しないため locale / 文言変更には依存しない。
+        let texts = try renderedTexts(existingCount: 1)
+        XCTAssertTrue(
+            texts.contains { !$0.hasSuffix("コイン") && $0.contains("1") },
+            "existingCount(1) を表す Text が見つからない。描画された Text: \(texts)"
         )
-        let label = try view.inspect().find(viewWithAccessibilityIdentifier: "existing_count_label")
-        let text = try label.find(ViewType.Text.self).string()
-        XCTAssertTrue(text.contains("1"))
     }
 
     func test_existingCountRow_visible_whenCountIsMany() throws {
-        let view = TaskCardView(
-            task: makeTask(),
-            isSelected: false,
-            existingCount: 3,
-            onTap: {}
+        let texts = try renderedTexts(existingCount: 3)
+        XCTAssertTrue(
+            texts.contains { !$0.hasSuffix("コイン") && $0.contains("3") },
+            "existingCount(3) を表す Text が見つからない。描画された Text: \(texts)"
         )
-        let label = try view.inspect().find(viewWithAccessibilityIdentifier: "existing_count_label")
-        let text = try label.find(ViewType.Text.self).string()
-        XCTAssertTrue(text.contains("3"))
     }
 }


### PR DESCRIPTION
## 概要

`OtetsudaiCoinTests/TaskCardViewTests` の以下 2 件が main で決定的に失敗していたのを修正する (Closes #106)。

- `test_existingCountRow_visible_whenCountIsOne()`
- `test_existingCountRow_visible_whenCountIsMany()`

## 根本原因 (再現確認済み)

`find(viewWithAccessibilityIdentifier: "existing_count_label")` が、`TaskCardView` 内の `Image(systemName:)` × 3 (taskIcon `hands.sparkles` / existingCountRow `checkmark.seal` / selectionIndicator `circle`) が `AccessibilityImageLabel` blocker となり該当 Text へ到達できず失敗する。CLAUDE.md「SwiftUI View テスト戦略 § AccessibilityImageLabel blocker」既知制約。

修正前にローカルで `xcodebuild test -only-testing:OtetsudaiCoinTests/TaskCardViewTests` を実行し、`count=0` の hidden test は PASS / `count>=1` の 2 件が FAIL することを再現確認した (issue 記載の症状と一致)。

## 修正方針

`findAll(ViewType.Text.self)` が blocker を跨いで Text を収集できることを実行で検証し、これに切替えた。

**issue 提案 (`contains("1")`) の落とし穴を改良:** `makeTask()` の `coinRate: 10` により coinInfo が `"10コイン"` を描画するため、`contains("1")` だけだと existingCountRow が無くても通る false positive になる。`"...コイン"` suffix を除外してから count 数字の有無を判定することで取り違えを防いだ。文言を exact match しないため locale / 文言変更にも依存しない。

```swift
let texts = try renderedTexts(existingCount: 1)
XCTAssertTrue(
    texts.contains { !$0.hasSuffix("コイン") && $0.contains("1") },
    "existingCount(1) を表す Text が見つからない。描画された Text: \(texts)"
)
```

## Plan からの逸脱

- **count=0 の hidden test は据え置き**: `XCTAssertThrowsError(find(viewWithAccessibilityIdentifier:))` 系で PASS を継続しており、issue スコープ (失敗 2 件) 外のため最小変更とした。なお同 idiom は label が「不在」でも「blocker で到達不可」でも throw して PASS するため、厳密には「row が hidden であること」を直接は検証していない (blocker-masked)。findAll idiom への統一は将来の改善余地として残す。

## テスト結果

```
Test case 'TaskCardViewTests.test_existingCountRow_hidden_whenCountIsZero()' passed
Test case 'TaskCardViewTests.test_existingCountRow_visible_whenCountIsMany()' passed
Test case 'TaskCardViewTests.test_existingCountRow_visible_whenCountIsOne()' passed
** TEST SUCCEEDED **
```

`iPhone 17` simulator で `-only-testing:OtetsudaiCoinTests/TaskCardViewTests` を実行し 3/3 green を確認 (本 PR は test ファイル単独変更で production code は不変)。

## 関連

- Closes #106
- 発見元: PR #105 (#104 errorPublisher 削除) の検証中
- CLAUDE.md「SwiftUI View テスト戦略 § AccessibilityImageLabel blocker」

🤖 Generated with [Claude Code](https://claude.com/claude-code)