### PR TITLE
fix(#112): テスト日付境界バグを修正 (月初1〜5日に決定的 fail)

### DIFF
--- a/app/OtetsudaiCoinTests/Domain/HelpRecordTests.swift
+++ b/app/OtetsudaiCoinTests/Domain/HelpRecordTests.swift
@@ -72,7 +72,13 @@ final class HelpRecordTests: XCTestCase {
         let now = Date()
         
         let currentMonthRecord1 = HelpRecord(id: UUID(), childId: childId, helpTaskId: helpTaskId, recordedAt: now)
-        let currentMonthRecord2 = HelpRecord(id: UUID(), childId: childId, helpTaskId: helpTaskId, recordedAt: calendar.date(byAdding: .day, value: -5, to: now)!)
+        // Issue #112: 元実装の `now - 5日` は月初1〜5日に前月へ回り込み、filterForChildInCurrentMonth が
+        // 正しく前月分を除外して count=1 となり毎月1〜5日に必ず fail していた (プロダクトコードは正常)。
+        // 当月内に必ず収まる固定日 (当月15日) を使い、実行日に依存しない決定的なテストにする。
+        var currentMonthComponents = calendar.dateComponents([.year, .month], from: now)
+        currentMonthComponents.day = 15
+        let midCurrentMonth = calendar.date(from: currentMonthComponents)!
+        let currentMonthRecord2 = HelpRecord(id: UUID(), childId: childId, helpTaskId: helpTaskId, recordedAt: midCurrentMonth)
         let otherChildRecord = HelpRecord(id: UUID(), childId: otherChildId, helpTaskId: helpTaskId, recordedAt: now)
         let previousMonthRecord = HelpRecord(id: UUID(), childId: childId, helpTaskId: helpTaskId, recordedAt: calendar.date(byAdding: .month, value: -1, to: now)!)
         


### PR DESCRIPTION
## 概要

`HelpRecordTests.testFilterRecordsForChildInCurrentMonth()` が **毎月1〜5日に決定的に fail** する日付境界バグを修正する (Issue #112)。

## 根本原因

テストは `currentMonthRecord2` を `calendar.date(byAdding: .day, value: -5, to: now)` で生成していた。今日が月初1〜5日だと `now - 5日` が**前月**へ回り込み、`HelpRecord.filterForChildInCurrentMonth` が正しく前月分を除外して `count=1` となり、期待値 `2` と不一致で fail する。**プロダクトコードは正常で、テスト側の前提が誤っていた。**

## 修正

`currentMonthRecord2` を「当月15日」の固定日に変更し、実行日に依存しない決定的なテストにした。

- day 15 は全月で存在し常に当月内
- year boundary も `isInCurrentMonth()` が year+month 粒度 (`isDate(equalTo:toGranularity:.month)`) で比較するため安全
- `currentMonthRecord1 = now` / `previousMonthRecord = now - 1month` の他2件は元から境界をまたがないため変更不要

## Plan からの逸脱 / 案の選定理由

Issue 本文は **「(b) injected clock が最も頑健」** を推奨していたが、本 PR は **(a) 当月クランプ (test-only)** を採用した。理由:

- 本バグは **test-only** かつ **優先度 LOW**（プロダクト挙動は正常）
- (b) は `HelpRecord.isInCurrentMonth()` に clock を注入する **プロダクト API 変更**を伴い、test-only バグに対してスコープ過剰
- (a) はテスト1ファイルの変更で決定性を完全担保でき、コスト/リスク比が最良

## 検証

today = **2026-06-02 (month day 2 = 再現窓内)** で TDD サイクルを実施:

| 段階 | コマンド | 結果 |
|---|---|---|
| RED (修正前) | `xcodebuild test -only-testing:.../testFilterRecordsForChildInCurrentMonth` | `** TEST FAILED **` / `EXIT=65` (実 fail を観測) |
| GREEN (修正後・単体) | 同上 | `** TEST SUCCEEDED **` / `EXIT=0` |
| GREEN (修正後・クラス全体) | `-only-testing:OtetsudaiCoinTests/HelpRecordTests` | 全6件 passed / `** TEST SUCCEEDED **` |

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)