### PR TITLE
feat(#84): 記録日カレンダーで記録のある日を可視化

### DIFF
--- a/app/OtetsudaiCoin/Presentation/Components/RecordCalendarView.swift
+++ b/app/OtetsudaiCoin/Presentation/Components/RecordCalendarView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+
+/// 記録画面の「記録日」用インライン月カレンダー。
+/// 選択中の子どもの記録がある日に緑ドットを表示し、記録漏れ・二重登録に事前に気づけるようにする (#84)。
+/// 純プレゼンテーショナル: 状態は引数、操作はクロージャで親 (RecordView/RecordViewModel) に委譲。
+/// `Image(systemName:)` を使わず AccessibilityImageLabel blocker を避ける設計。
+struct RecordCalendarView: View {
+    let displayedMonth: Date      // 表示中の月 (月初アンカー)
+    let selectedDate: Date        // 選択中の記録日
+    let recordedDays: Set<Int>    // displayedMonth 内で記録がある日
+    let today: Date               // 未来日判定の基準
+    let canGoNextMonth: Bool
+    let onSelectDay: (Int) -> Void
+    let onPrevMonth: () -> Void
+    let onNextMonth: () -> Void
+
+    private let cal = Calendar.current
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            weekdayHeader
+            ForEach(Array(weeks.enumerated()), id: \.offset) { _, week in
+                HStack(spacing: 4) {
+                    ForEach(Array(week.enumerated()), id: \.offset) { _, day in
+                        if let day {
+                            dayCell(day)
+                        } else {
+                            Color.clear.frame(maxWidth: .infinity).frame(height: 38)
+                        }
+                    }
+                }
+            }
+            selectedCaption
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Button(action: onPrevMonth) {
+                Text("‹").font(.title2).frame(width: 44, height: 32)
+            }
+            .accessibilityIdentifier("calendar_prev_month")
+            .accessibilityLabel(Text(String(localized: "前の月")))
+
+            Spacer()
+            Text(monthTitle).appFont(.sectionHeader)
+            Spacer()
+
+            Button(action: onNextMonth) {
+                Text("›").font(.title2).frame(width: 44, height: 32)
+                    .opacity(canGoNextMonth ? 1 : 0.3)
+            }
+            .disabled(!canGoNextMonth)
+            .accessibilityIdentifier("calendar_next_month")
+            .accessibilityLabel(Text(String(localized: "次の月")))
+        }
+    }
+
+    private var weekdayHeader: some View {
+        HStack(spacing: 4) {
+            ForEach(orderedWeekdaySymbols, id: \.self) { sym in
+                Text(sym)
+                    .font(.caption2)
+                    .foregroundColor(AccessibilityColors.textSecondary)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    // MARK: - Day cell
+
+    private func dayCell(_ day: Int) -> some View {
+        let isRecorded = recordedDays.contains(day)
+        let isSelected = selectedDayInDisplayedMonth == day
+        let isFuture = isFutureDay(day)
+        return Button {
+            onSelectDay(day)
+        } label: {
+            VStack(spacing: 2) {
+                Text("\(day)")
+                    .font(.system(size: 15))
+                    .foregroundColor(dayForeground(isFuture: isFuture, isSelected: isSelected))
+                    .frame(width: 30, height: 30)
+                    .background {
+                        if isSelected {
+                            Circle().fill(AccessibilityColors.primaryBlue)
+                        }
+                    }
+                Circle()
+                    .fill(isRecorded ? AccessibilityColors.successGreen : Color.clear)
+                    .frame(width: 6, height: 6)
+                    .accessibilityHidden(true)  // 記録有無は cell の accessibilityLabel ("記録あり"/"記録なし") が伝える
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .disabled(isFuture)
+        .accessibilityIdentifier("calendar_day_\(day)")
+        .accessibilityLabel(Text(dayAccessibilityLabel(day, isRecorded: isRecorded, isSelected: isSelected, isFuture: isFuture)))
+    }
+
+    private func dayForeground(isFuture: Bool, isSelected: Bool) -> Color {
+        if isFuture { return AccessibilityColors.textDisabled }
+        if isSelected { return .white }
+        return AccessibilityColors.textPrimary
+    }
+
+    private var selectedCaption: some View {
+        HStack(spacing: 6) {
+            Text(String(localized: "記録日")).appFont(.secondaryInfo)
+                .foregroundColor(AccessibilityColors.textSecondary)
+            Text(selectedDate, format: .dateTime.year().month().day())
+                .appFont(.secondaryInfo)
+        }
+        .padding(.top, 2)
+    }
+
+    // MARK: - Derived data
+
+    private var monthTitle: String {
+        let f = DateFormatter()
+        f.locale = .current
+        f.setLocalizedDateFormatFromTemplate("yMMMM")
+        return f.string(from: displayedMonth)
+    }
+
+    private var orderedWeekdaySymbols: [String] {
+        let symbols = cal.shortWeekdaySymbols          // index 0 = Sunday
+        let first = cal.firstWeekday - 1
+        return Array(symbols[first...] + symbols[..<first])
+    }
+
+    /// 週ごとに分割した日番号 (前方の空白は nil)。
+    private var weeks: [[Int?]] {
+        guard let range = cal.range(of: .day, in: .month, for: displayedMonth) else { return [] }
+        let firstWeekday = cal.component(.weekday, from: displayedMonth) // 1=Sun..7=Sat
+        let leading = (firstWeekday - cal.firstWeekday + 7) % 7
+        var cells: [Int?] = Array(repeating: nil, count: leading)
+        cells.append(contentsOf: range.map { Optional($0) })
+        while cells.count % 7 != 0 { cells.append(nil) }
+        return stride(from: 0, to: cells.count, by: 7).map { Array(cells[$0 ..< $0 + 7]) }
+    }
+
+    /// selectedDate が displayedMonth と同じ年月なら、その日。違えば nil (ハイライトしない)。
+    private var selectedDayInDisplayedMonth: Int? {
+        let d = cal.dateComponents([.year, .month, .day], from: selectedDate)
+        let m = cal.dateComponents([.year, .month], from: displayedMonth)
+        return (d.year == m.year && d.month == m.month) ? d.day : nil
+    }
+
+    private func isFutureDay(_ day: Int) -> Bool {
+        var comps = cal.dateComponents([.year, .month], from: displayedMonth)
+        comps.day = day
+        guard let date = cal.date(from: comps) else { return false }
+        return cal.startOfDay(for: date) > cal.startOfDay(for: today)
+    }
+
+    private func dayAccessibilityLabel(_ day: Int, isRecorded: Bool, isSelected: Bool, isFuture: Bool) -> String {
+        var comps = cal.dateComponents([.year, .month], from: displayedMonth)
+        comps.day = day
+        let date = cal.date(from: comps) ?? displayedMonth
+        var parts = [date.formatted(.dateTime.year().month().day())]
+        parts.append(isRecorded ? String(localized: "記録あり") : String(localized: "記録なし"))
+        if isSelected { parts.append(String(localized: "選択中")) }
+        if isFuture { parts.append(String(localized: "選択できません")) }
+        return parts.joined(separator: "、")
+    }
+}

--- a/app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift
@@ -16,6 +16,8 @@ class RecordViewModel: BaseViewModel {
     var selectedTaskIds: Set<UUID> = []
     var warningMessage: String? = nil
     var existingRecordCounts: [UUID: Int] = [:]
+    var displayedMonth: Date = RecordViewModel.startOfMonth(Date())
+    var recordedDays: Set<Int> = []
 
     func existingRecordCount(for taskId: UUID) -> Int {
         return existingRecordCounts[taskId] ?? 0
@@ -40,7 +42,8 @@ class RecordViewModel: BaseViewModel {
     private let soundService: SoundServiceProtocol
     private var loadChildrenTask: Task<Void, Never>?
     private var loadCountsTask: Task<Void, Never>?
-    
+    private var loadRecordedDaysTask: Task<Void, Never>?
+
     init(
         childRepository: ChildRepository,
         helpTaskRepository: HelpTaskRepository,
@@ -339,9 +342,49 @@ class RecordViewModel: BaseViewModel {
         }
     }
 
+    @MainActor
+    func loadRecordedDaysForDisplayedMonth() {
+        loadRecordedDaysTask?.cancel()
+
+        guard let child = selectedChild else {
+            recordedDays = []
+            return
+        }
+
+        let cal = Calendar.current
+        let monthStart = RecordViewModel.startOfMonth(displayedMonth)
+        guard let monthEnd = cal.date(byAdding: DateComponents(month: 1, second: -1), to: monthStart) else {
+            return
+        }
+
+        loadRecordedDaysTask = Task { [weak self] in
+            guard let self = self else { return }
+            do {
+                let records = try await self.helpRecordRepository.findByDateRange(from: monthStart, to: monthEnd)
+                guard !Task.isCancelled else { return }
+                let days = Set(
+                    records
+                        .filter { $0.childId == child.id }
+                        .map { cal.component(.day, from: $0.recordedAt) }
+                )
+                await MainActor.run {
+                    self.recordedDays = days
+                }
+            } catch {
+                // 取得失敗は無視 (UX 影響低・既存 errorMessage を上書きしない)
+            }
+        }
+    }
+
     private static func normalizeToNoon(_ date: Date) -> Date {
         let cal = Calendar.current
         let startOfDay = cal.startOfDay(for: date)
         return cal.date(byAdding: .hour, value: 12, to: startOfDay) ?? startOfDay
+    }
+
+    static func startOfMonth(_ date: Date) -> Date {
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.year, .month], from: date)
+        return cal.date(from: comps) ?? cal.startOfDay(for: date)
     }
 }

--- a/app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift
@@ -376,6 +376,40 @@ class RecordViewModel: BaseViewModel {
         }
     }
 
+    func canGoToNextMonth(today: Date = Date()) -> Bool {
+        displayedMonth < RecordViewModel.startOfMonth(today)
+    }
+
+    @MainActor
+    func goToPreviousMonth() {
+        let cal = Calendar.current
+        guard let prev = cal.date(byAdding: .month, value: -1, to: displayedMonth) else { return }
+        displayedMonth = RecordViewModel.startOfMonth(prev)
+        loadRecordedDaysForDisplayedMonth()
+    }
+
+    @MainActor
+    func goToNextMonth(today: Date = Date()) {
+        guard canGoToNextMonth(today: today) else { return }
+        let cal = Calendar.current
+        guard let next = cal.date(byAdding: .month, value: 1, to: displayedMonth) else { return }
+        displayedMonth = RecordViewModel.startOfMonth(next)
+        loadRecordedDaysForDisplayedMonth()
+    }
+
+    @MainActor
+    func selectDay(_ day: Int, today: Date = Date()) {
+        let cal = Calendar.current
+        var comps = cal.dateComponents([.year, .month], from: displayedMonth)
+        comps.day = day
+        guard let date = cal.date(from: comps) else { return }
+        // 未来日は無視 (View 側でも disabled だが二重防御)
+        if cal.startOfDay(for: date) > cal.startOfDay(for: today) { return }
+        recordedDate = RecordViewModel.normalizeToNoon(date)
+        // 旧 DatePicker .onChange 相当: 選択日の per-task 件数 (#73) を更新
+        loadExistingCountsForCurrentDateAndChild()
+    }
+
     private static func normalizeToNoon(_ date: Date) -> Date {
         let cal = Calendar.current
         let startOfDay = cal.startOfDay(for: date)

--- a/app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift
@@ -111,6 +111,7 @@ class RecordViewModel: BaseViewModel {
 
                 setLoading(false)
                 loadExistingCountsForCurrentDateAndChild()
+                loadRecordedDaysForDisplayedMonth()   // ← 追加
             } catch {
                 guard !Task.isCancelled else { return }
                 setUserFriendlyError(error)
@@ -167,8 +168,9 @@ class RecordViewModel: BaseViewModel {
         // 成功メッセージは保持し、エラーメッセージのみクリア
         clearErrorMessage()
         loadExistingCountsForCurrentDateAndChild()
+        loadRecordedDaysForDisplayedMonth()   // ← 追加
     }
-    
+
     func setPreselectedChild(_ child: Child) {
         selectedChild = child
     }

--- a/app/OtetsudaiCoin/Presentation/Views/RecordView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/RecordView.swift
@@ -130,26 +130,16 @@ struct RecordView: View {
     }
 
     private var dateSection: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "calendar")
-                .foregroundColor(.blue)
-                .font(.title3)
-            Text(String(localized: "記録日"))
-                .appFont(.sectionHeader)
-            Spacer()
-            DatePicker(
-                "",
-                selection: $viewModel.recordedDate,
-                in: ...Date(),
-                displayedComponents: .date
-            )
-            .labelsHidden()
-            .datePickerStyle(.compact)
-            .accessibilityIdentifier("record_date_picker")
-            .onChange(of: viewModel.recordedDate) { _, _ in
-                viewModel.loadExistingCountsForCurrentDateAndChild()
-            }
-        }
+        RecordCalendarView(
+            displayedMonth: viewModel.displayedMonth,
+            selectedDate: viewModel.recordedDate,
+            recordedDays: viewModel.recordedDays,
+            today: Date(),
+            canGoNextMonth: viewModel.canGoToNextMonth(),
+            onSelectDay: { viewModel.selectDay($0) },
+            onPrevMonth: { viewModel.goToPreviousMonth() },
+            onNextMonth: { viewModel.goToNextMonth() }
+        )
         .padding(.horizontal)
     }
     

--- a/app/OtetsudaiCoin/Resources/Localizable.xcstrings
+++ b/app/OtetsudaiCoin/Resources/Localizable.xcstrings
@@ -1848,6 +1848,26 @@
         }
       }
     },
+    "次の月" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next month"
+          }
+        }
+      }
+    },
+    "前の月" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous month"
+          }
+        }
+      }
+    },
     "準備完了です！" : {
       "localizations" : {
         "en" : {
@@ -1938,6 +1958,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Record"
+          }
+        }
+      }
+    },
+    "記録あり" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recorded"
+          }
+        }
+      }
+    },
+    "記録なし" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not recorded"
           }
         }
       }
@@ -2234,6 +2274,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selected"
+          }
+        }
+      }
+    },
+    "選択できません" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unavailable"
           }
         }
       }

--- a/app/OtetsudaiCoinTests/Presentation/Components/RecordCalendarViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/RecordCalendarViewTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import OtetsudaiCoin
+
+/// RecordCalendarView のコンポーネントテスト。
+///
+/// ## 設計上の注意 (findAll fallback)
+/// ViewInspector 0.10.2 + iOS 26 SDK の組み合わせで
+/// `accessibilityIdentifier()` が全ビュータイプで nil / throw を返す
+/// (v3v4AccessibilityProperties が iOS 26 内部構造変化で取得不可)。
+/// そのため `find(viewWithAccessibilityIdentifier:)` が全ケースで SearchFailure になる。
+///
+/// 代替戦略:
+/// - ボタン系: `findAll(ViewType.Button.self)` + 内包 Text でフィルタ
+/// - ドット系: `fillShapeStyle(Color.self)` で Circle の fill 色を直接確認
+///   (button サブツリー内の Shape を `findAll(ViewType.Shape.self)` で列挙)
+///
+/// `tap()` / `isDisabled()` はボタンタイプ上で正常動作することをローカル実行で確認済み。
+/// CLAUDE.md § SwiftUI View テスト戦略 "findAll fallback" に準拠。
+@MainActor
+final class RecordCalendarViewTests: XCTestCase {
+
+    private let cal = Calendar.current
+
+    /// 2026-06 を表示月、今日=2026-06-15 とした標準セットアップ。
+    private func makeView(
+        recordedDays: Set<Int> = [],
+        selectedDay: Int? = nil,
+        onSelectDay: @escaping (Int) -> Void = { _ in },
+        onPrevMonth: @escaping () -> Void = {},
+        onNextMonth: @escaping () -> Void = {},
+        canGoNextMonth: Bool = false
+    ) -> RecordCalendarView {
+        let displayedMonth = cal.date(from: DateComponents(year: 2026, month: 6, day: 1))!
+        let today = cal.date(from: DateComponents(year: 2026, month: 6, day: 15))!
+        let selectedDate = selectedDay.flatMap {
+            cal.date(from: DateComponents(year: 2026, month: 6, day: $0, hour: 12))
+        } ?? cal.date(from: DateComponents(year: 2030, month: 1, day: 1))!  // 既定は表示月外
+        return RecordCalendarView(
+            displayedMonth: displayedMonth,
+            selectedDate: selectedDate,
+            recordedDays: recordedDays,
+            today: today,
+            canGoNextMonth: canGoNextMonth,
+            onSelectDay: onSelectDay,
+            onPrevMonth: onPrevMonth,
+            onNextMonth: onNextMonth
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// ボタンサブツリー内の Shape の fill 色リストを返す。
+    /// 記録ありの日は successGreen (#00AA44FF) の Circle が含まれる。
+    private func shapeFills(in button: InspectableView<ViewType.Button>) -> [Color] {
+        return button.findAll(ViewType.Shape.self).compactMap { try? $0.fillShapeStyle(Color.self) }
+    }
+
+    // MARK: - Tests
+
+    /// 記録がある日 (5, 20) には緑 fill の Circle が存在し、記録なし (3) には存在しない。
+    func test_recordDot_shownForRecordedDay_hiddenForOthers() throws {
+        let view = makeView(recordedDays: [5, 20])
+        let allButtons = try view.inspect().findAll(ViewType.Button.self)
+        let btn5 = allButtons.first(where: { (try? $0.find(text: "5")) != nil })
+        let btn20 = allButtons.first(where: { (try? $0.find(text: "20")) != nil })
+        let btn3 = allButtons.first(where: { (try? $0.find(text: "3")) != nil })
+        let dotColor = AccessibilityColors.successGreen
+        XCTAssertTrue(
+            btn5.map { shapeFills(in: $0).contains(dotColor) } ?? false,
+            "5日の Circle に successGreen fill がない。allButtons=\(allButtons.count), fills=\(btn5.map { shapeFills(in: $0) } ?? [])"
+        )
+        XCTAssertTrue(
+            btn20.map { shapeFills(in: $0).contains(dotColor) } ?? false,
+            "20日の Circle に successGreen fill がない。allButtons=\(allButtons.count), fills=\(btn20.map { shapeFills(in: $0) } ?? [])"
+        )
+        XCTAssertFalse(
+            btn3.map { shapeFills(in: $0).contains(dotColor) } ?? false,
+            "3日に余計な successGreen dot がある。fills=\(btn3.map { shapeFills(in: $0) } ?? [])"
+        )
+    }
+
+    /// 表示月内の選択日 (12) には primaryBlue の選択リングがあり、非選択日 (10) には無い。
+    /// dot テストと同じ findAll(ViewType.Shape.self) + fillShapeStyle 方式で
+    /// Circle の fill 色 (#0066CCFF) を直接確認する。
+    func test_selectionCircle_shownForSelectedDayInMonth() throws {
+        let view = makeView(selectedDay: 12)
+        let allButtons = try view.inspect().findAll(ViewType.Button.self)
+        let btn12 = allButtons.first(where: { (try? $0.find(text: "12")) != nil })
+        let btn10 = allButtons.first(where: { (try? $0.find(text: "10")) != nil })
+        let selectionColor = AccessibilityColors.primaryBlue
+        XCTAssertTrue(
+            btn12.map { shapeFills(in: $0).contains(selectionColor) } ?? false,
+            "選択日(12)の Circle に primaryBlue fill がない。allButtons=\(allButtons.count), fills=\(btn12.map { shapeFills(in: $0) } ?? [])"
+        )
+        XCTAssertFalse(
+            btn10.map { shapeFills(in: $0).contains(selectionColor) } ?? false,
+            "非選択日(10)に余計な primaryBlue 選択リングがある。fills=\(btn10.map { shapeFills(in: $0) } ?? [])"
+        )
+    }
+
+    /// 日セルをタップすると onSelectDay にその日が渡る。
+    func test_tapDay_callsOnSelectDayWithDay() throws {
+        var tapped: Int?
+        let view = makeView(onSelectDay: { tapped = $0 })
+        let allButtons = try view.inspect().findAll(ViewType.Button.self)
+        guard let btn10 = allButtons.first(where: { (try? $0.find(text: "10")) != nil }) else {
+            XCTFail("calendar_day_10 が見つからない (allButtons=\(allButtons.count))")
+            return
+        }
+        try btn10.tap()
+        XCTAssertEqual(tapped, 10, "タップした 10日 が onSelectDay に渡らなかった (allButtons=\(allButtons.count))")
+    }
+
+    /// 未来日 (今日 2026-06-15 より後) は disabled、過去日・今日は enabled。
+    func test_futureDay_buttonDisabled() throws {
+        let view = makeView()
+        let allButtons = try view.inspect().findAll(ViewType.Button.self)
+        guard let futureBtn = allButtons.first(where: { (try? $0.find(text: "16")) != nil }),
+              let pastBtn = allButtons.first(where: { (try? $0.find(text: "10")) != nil }),
+              let todayBtn = allButtons.first(where: { (try? $0.find(text: "15")) != nil }) else {
+            XCTFail("16日 / 10日 / 15日 ボタンが見つからない (allButtons=\(allButtons.count))")
+            return
+        }
+        XCTAssertTrue(
+            futureBtn.isDisabled(),
+            "未来日(16)が disabled になっていない (allButtons=\(allButtons.count))"
+        )
+        XCTAssertFalse(
+            pastBtn.isDisabled(),
+            "過去日(10)が誤って disabled (allButtons=\(allButtons.count))"
+        )
+        // 今日 (15) は選択可能 (境界は strict `>` なので今日は disabled でない)
+        XCTAssertFalse(
+            todayBtn.isDisabled(),
+            "今日(15)が誤って disabled (allButtons=\(allButtons.count))"
+        )
+    }
+
+    /// canGoNextMonth=false のとき次月ボタンが disabled になる。
+    func test_nextMonthButton_disabledWhenCannotGoNext() throws {
+        let view = makeView(canGoNextMonth: false)
+        let allButtons = try view.inspect().findAll(ViewType.Button.self)
+        guard let next = allButtons.first(where: { (try? $0.find(text: "›")) != nil }) else {
+            XCTFail("次月ボタン(›)が見つからない (allButtons=\(allButtons.count))")
+            return
+        }
+        XCTAssertTrue(
+            next.isDisabled(),
+            "canGoNextMonth=false で次月ボタンが disabled でない (allButtons=\(allButtons.count))"
+        )
+    }
+
+    /// 前月ボタンをタップすると onPrevMonth が呼ばれる。
+    func test_tapPrevMonth_callsOnPrevMonth() throws {
+        var called = false
+        let view = makeView(onPrevMonth: { called = true })
+        let allButtons = try view.inspect().findAll(ViewType.Button.self)
+        guard let prev = allButtons.first(where: { (try? $0.find(text: "‹")) != nil }) else {
+            XCTFail("前月ボタン(‹)が見つからない (allButtons=\(allButtons.count))")
+            return
+        }
+        try prev.tap()
+        XCTAssertTrue(called, "前月ボタンのタップで onPrevMonth が呼ばれない (allButtons=\(allButtons.count))")
+    }
+}

--- a/app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
@@ -627,4 +627,53 @@ final class RecordViewModelTests: XCTestCase {
         // Then: count map が +1 されている
         XCTAssertEqual(viewModel.existingRecordCount(for: task.id), 1)
     }
+
+    // MARK: - #84 recordedDays (記録がある日の集合)
+
+    @MainActor
+    func test_recordedDays_initiallyEmpty() {
+        XCTAssertEqual(viewModel.recordedDays, [])
+    }
+
+    @MainActor
+    func test_loadRecordedDays_noSelectedChild_clearsSet() {
+        // Given: 何か入っている / selectedChild = nil
+        viewModel.recordedDays = [1, 2, 3]
+        viewModel.selectedChild = nil
+
+        // When (selectedChild == nil は同期的に空集合化)
+        viewModel.loadRecordedDaysForDisplayedMonth()
+
+        // Then
+        XCTAssertEqual(viewModel.recordedDays, [])
+    }
+
+    @MainActor
+    func test_loadRecordedDays_filtersBySelectedChildAndMonth() async {
+        // Given: childA の 3/5, 3/20 が対象。childB の 3/5・2月・4月 は除外。
+        let childA = Child(id: UUID(), name: "A", themeColor: "#FF5733")
+        let childB = Child(id: UUID(), name: "B", themeColor: "#33FF57")
+        let task = HelpTask(id: UUID(), name: "皿洗い", isActive: true, coinRate: 10)
+        let cal = Calendar.current
+        func noon(_ y: Int, _ m: Int, _ d: Int) -> Date {
+            cal.date(from: DateComponents(year: y, month: m, day: d, hour: 12))!
+        }
+        mockHelpTaskRepository.tasks = [task]
+        mockHelpRecordRepository.records = [
+            HelpRecord(id: UUID(), childId: childA.id, helpTaskId: task.id, recordedAt: noon(2026, 3, 5)),   // 対象
+            HelpRecord(id: UUID(), childId: childA.id, helpTaskId: task.id, recordedAt: noon(2026, 3, 20)),  // 対象
+            HelpRecord(id: UUID(), childId: childB.id, helpTaskId: task.id, recordedAt: noon(2026, 3, 5)),   // 除外(別child)
+            HelpRecord(id: UUID(), childId: childA.id, helpTaskId: task.id, recordedAt: noon(2026, 2, 28)),  // 除外(前月)
+            HelpRecord(id: UUID(), childId: childA.id, helpTaskId: task.id, recordedAt: noon(2026, 4, 1)),   // 除外(翌月)
+        ]
+        viewModel.selectedChild = childA
+        viewModel.displayedMonth = RecordViewModel.startOfMonth(noon(2026, 3, 15))
+
+        // When
+        viewModel.loadRecordedDaysForDisplayedMonth()
+        await waitUntil(timeout: 2.0) { self.viewModel.recordedDays == [5, 20] }
+
+        // Then
+        XCTAssertEqual(viewModel.recordedDays, [5, 20])
+    }
 }

--- a/app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
@@ -721,6 +721,28 @@ final class RecordViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_monthNavigation_handlesYearBoundary() {
+        let cal = Calendar.current
+        // goToPreviousMonth: 2026年1月 → 2025年12月 (年跨ぎ)
+        viewModel.displayedMonth = cal.date(from: DateComponents(year: 2026, month: 1, day: 1))!
+        viewModel.goToPreviousMonth()
+        XCTAssertEqual(viewModel.displayedMonth,
+                       cal.date(from: DateComponents(year: 2025, month: 12, day: 1))!)
+
+        // canGoToNextMonth: 2025年12月表示・今日=2026年1月 → 進める (年跨ぎ比較)
+        let todayJan = cal.date(from: DateComponents(year: 2026, month: 1, day: 10))!
+        XCTAssertTrue(viewModel.canGoToNextMonth(today: todayJan))
+
+        // goToNextMonth: 2025年12月 → 2026年1月 (年跨ぎ)
+        viewModel.goToNextMonth(today: todayJan)
+        XCTAssertEqual(viewModel.displayedMonth,
+                       cal.date(from: DateComponents(year: 2026, month: 1, day: 1))!)
+
+        // 今日の月 (2026年1月) で頭打ち
+        XCTAssertFalse(viewModel.canGoToNextMonth(today: todayJan))
+    }
+
+    @MainActor
     func test_selectDay_setsRecordedDateNoon_ignoresFuture() {
         let cal = Calendar.current
         let today = cal.date(from: DateComponents(year: 2026, month: 6, day: 15))!

--- a/app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
@@ -676,4 +676,70 @@ final class RecordViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.recordedDays, [5, 20])
     }
+
+    // MARK: - #84 月移動と日選択
+
+    @MainActor
+    func test_canGoToNextMonth_falseForCurrentMonth_trueForPast() {
+        let cal = Calendar.current
+        let today = cal.date(from: DateComponents(year: 2026, month: 6, day: 15))!
+
+        viewModel.displayedMonth = RecordViewModel.startOfMonth(today)
+        XCTAssertFalse(viewModel.canGoToNextMonth(today: today))
+
+        viewModel.displayedMonth = cal.date(from: DateComponents(year: 2026, month: 4, day: 1))!
+        XCTAssertTrue(viewModel.canGoToNextMonth(today: today))
+    }
+
+    @MainActor
+    func test_goToPreviousMonth_movesDisplayedMonthBack() {
+        let cal = Calendar.current
+        viewModel.displayedMonth = cal.date(from: DateComponents(year: 2026, month: 3, day: 1))!
+
+        viewModel.goToPreviousMonth()
+
+        XCTAssertEqual(
+            viewModel.displayedMonth,
+            cal.date(from: DateComponents(year: 2026, month: 2, day: 1))!
+        )
+    }
+
+    @MainActor
+    func test_goToNextMonth_cappedAtCurrentMonth() {
+        let cal = Calendar.current
+        let today = cal.date(from: DateComponents(year: 2026, month: 6, day: 15))!
+
+        // 過去月からは進める
+        viewModel.displayedMonth = cal.date(from: DateComponents(year: 2026, month: 4, day: 1))!
+        viewModel.goToNextMonth(today: today)
+        XCTAssertEqual(viewModel.displayedMonth, cal.date(from: DateComponents(year: 2026, month: 5, day: 1))!)
+
+        // 今日の月で頭打ち (no-op)
+        viewModel.displayedMonth = RecordViewModel.startOfMonth(today)
+        viewModel.goToNextMonth(today: today)
+        XCTAssertEqual(viewModel.displayedMonth, RecordViewModel.startOfMonth(today))
+    }
+
+    @MainActor
+    func test_selectDay_setsRecordedDateNoon_ignoresFuture() {
+        let cal = Calendar.current
+        let today = cal.date(from: DateComponents(year: 2026, month: 6, day: 15))!
+        viewModel.displayedMonth = RecordViewModel.startOfMonth(today)
+
+        // 過去日は選択され noon 正規化される
+        viewModel.selectDay(10, today: today)
+        let comps = cal.dateComponents([.year, .month, .day, .hour], from: viewModel.recordedDate)
+        XCTAssertEqual(comps.year, 2026)
+        XCTAssertEqual(comps.month, 6)
+        XCTAssertEqual(comps.day, 10)
+        XCTAssertEqual(comps.hour, 12)
+
+        // 今日 (15) は選択可能 (guard は strict `>` なので今日は通る)
+        viewModel.selectDay(15, today: today)
+        XCTAssertEqual(cal.component(.day, from: viewModel.recordedDate), 15)
+
+        // 未来日 (16) は無視され recordedDate は 15 のまま
+        viewModel.selectDay(16, today: today)
+        XCTAssertEqual(cal.component(.day, from: viewModel.recordedDate), 15)
+    }
 }

--- a/app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
@@ -742,4 +742,33 @@ final class RecordViewModelTests: XCTestCase {
         viewModel.selectDay(16, today: today)
         XCTAssertEqual(cal.component(.day, from: viewModel.recordedDate), 15)
     }
+
+    @MainActor
+    func test_selectChild_triggersRecordedDaysReload() async {
+        let cal = Calendar.current
+        let base = RecordViewModel.startOfMonth(Date())
+        func noon(_ d: Int) -> Date {
+            cal.date(byAdding: DateComponents(day: d - 1, hour: 12), to: base)!
+        }
+        let childA = Child(id: UUID(), name: "A", themeColor: "#FF5733")
+        let childB = Child(id: UUID(), name: "B", themeColor: "#33FF57")
+        let task = HelpTask(id: UUID(), name: "皿洗い", isActive: true, coinRate: 10)
+        mockHelpTaskRepository.tasks = [task]
+        mockHelpRecordRepository.records = [
+            HelpRecord(id: UUID(), childId: childA.id, helpTaskId: task.id, recordedAt: noon(3)),
+            HelpRecord(id: UUID(), childId: childB.id, helpTaskId: task.id, recordedAt: noon(7)),
+            HelpRecord(id: UUID(), childId: childB.id, helpTaskId: task.id, recordedAt: noon(9)),
+        ]
+        // displayedMonth を records と同じ月アンカーに固定し、月境界 race を排除
+        viewModel.displayedMonth = base
+        viewModel.selectChild(childA)
+        await waitUntil(timeout: 2.0) { self.viewModel.recordedDays == [3] }
+
+        // When: childB に切替 → {7, 9}
+        viewModel.selectChild(childB)
+
+        // Then
+        await waitUntil(timeout: 2.0) { self.viewModel.recordedDays == [7, 9] }
+        XCTAssertEqual(viewModel.recordedDays, [7, 9])
+    }
 }

--- a/docs/superpowers/plans/2026-06-05-issue-84-recorded-days-calendar.md
+++ b/docs/superpowers/plans/2026-06-05-issue-84-recorded-days-calendar.md
@@ -1,0 +1,829 @@
+# Issue #84 記録日カレンダー可視化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 記録画面の `.compact` DatePicker を、選択中の子どもの記録がある日を緑ドットで示すインライン月カレンダーに置換し、記録漏れ・二重登録に事前に気づけるようにする。
+
+**Architecture:** ロジック（記録日集合の算出・月移動・日選択）は `RecordViewModel` に追加して unit-test 可能にし、表示は純プレゼンテーショナルな `RecordCalendarView`（`Presentation/Components/`）へ分離。reload は data-lifecycle 入口（`loadData`/`selectChild`/月移動/`selectDay`）にのみ集約し、write 操作内では呼ばない（#73 学び）。`Image(systemName:)` を使わず blocker を発生させない設計で component test を書く。
+
+**Tech Stack:** SwiftUI, `@Observable` ViewModel, XCTest + ViewInspector, Core Data 経由の `HelpRecordRepository`。
+
+**設計 spec:** `docs/superpowers/specs/2026-06-05-issue-84-recorded-days-calendar-design.md`
+**Branch:** `feat/issue-84-recorded-days-calendar`（spec commit `6cecfc3` 済み）
+
+---
+
+## File Structure
+
+- **Modify** `app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift`
+  追加状態 `displayedMonth` / `recordedDays`、メソッド `loadRecordedDaysForDisplayedMonth` / `goToPreviousMonth` / `goToNextMonth` / `canGoToNextMonth` / `selectDay` / `startOfMonth`、reload trigger を `loadData` と `selectChild` 末尾に追記。
+- **Create** `app/OtetsudaiCoin/Presentation/Components/RecordCalendarView.swift`
+  月カレンダーの純表示コンポーネント。状態は引数、操作はクロージャ。
+- **Modify** `app/OtetsudaiCoin/Presentation/Views/RecordView.swift`
+  `dateSection` の DatePicker を `RecordCalendarView` に置換、旧 `.onChange(of: recordedDate)` を撤去（`selectDay` 内で代替）。
+- **Modify (test)** `app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift`
+  ViewModel ロジックのテスト追加。
+- **Create (test)** `app/OtetsudaiCoinTests/Presentation/Components/RecordCalendarViewTests.swift`
+  コンポーネント behavior テスト。
+
+**テスト実行コマンド（共通）:**
+```bash
+xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -only-testing:<指定> 2>&1 | tee /tmp/issue84-test.log | tail -40
+```
+判定は `grep -F "** TEST FAILED" /tmp/issue84-test.log` が無いこと＋ `grep -E "Test Suite .* passed|Failing tests:" /tmp/issue84-test.log` で確認（background chain の exit 0 を鵜呑みにしない — CLAUDE.md flake 学び）。
+
+---
+
+## Task 1: ViewModel — `recordedDays` 算出と `startOfMonth`
+
+**Files:**
+- Modify: `app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift`
+- Test: `app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift`
+
+- [ ] **Step 1: Write failing tests**（`RecordViewModelTests.swift` の末尾 `}` の直前、`// MARK: - #73` 群の後に追記）
+
+```swift
+    // MARK: - #84 recordedDays (記録がある日の集合)
+
+    @MainActor
+    func test_recordedDays_initiallyEmpty() {
+        XCTAssertEqual(viewModel.recordedDays, [])
+    }
+
+    @MainActor
+    func test_loadRecordedDays_noSelectedChild_clearsSet() {
+        // Given: 何か入っている / selectedChild = nil
+        viewModel.recordedDays = [1, 2, 3]
+        viewModel.selectedChild = nil
+
+        // When (selectedChild == nil は同期的に空集合化)
+        viewModel.loadRecordedDaysForDisplayedMonth()
+
+        // Then
+        XCTAssertEqual(viewModel.recordedDays, [])
+    }
+
+    @MainActor
+    func test_loadRecordedDays_filtersBySelectedChildAndMonth() async {
+        // Given: childA の 3/5, 3/20 が対象。childB の 3/5・2月・4月 は除外。
+        let childA = Child(id: UUID(), name: "A", themeColor: "#FF5733")
+        let childB = Child(id: UUID(), name: "B", themeColor: "#33FF57")
+        let task = HelpTask(id: UUID(), name: "皿洗い", isActive: true, coinRate: 10)
+        let cal = Calendar.current
+        func noon(_ y: Int, _ m: Int, _ d: Int) -> Date {
+            cal.date(from: DateComponents(year: y, month: m, day: d, hour: 12))!
+        }
+        mockHelpTaskRepository.tasks = [task]
+        mockHelpRecordRepository.records = [
+            HelpRecord(id: UUID(), childId: childA.id, helpTaskId: task.id, recordedAt: noon(2026, 3, 5)),   // 対象
+            HelpRecord(id: UUID(), childId: childA.id, helpTaskId: task.id, recordedAt: noon(2026, 3, 20)),  // 対象
+            HelpRecord(id: UUID(), childId: childB.id, helpTaskId: task.id, recordedAt: noon(2026, 3, 5)),   // 除外(別child)
+            HelpRecord(id: UUID(), childId: childA.id, helpTaskId: task.id, recordedAt: noon(2026, 2, 28)),  // 除外(前月)
+            HelpRecord(id: UUID(), childId: childA.id, helpTaskId: task.id, recordedAt: noon(2026, 4, 1)),   // 除外(翌月)
+        ]
+        viewModel.selectedChild = childA
+        viewModel.displayedMonth = RecordViewModel.startOfMonth(noon(2026, 3, 15))
+
+        // When
+        viewModel.loadRecordedDaysForDisplayedMonth()
+        await waitUntil(timeout: 2.0) { self.viewModel.recordedDays == [5, 20] }
+
+        // Then
+        XCTAssertEqual(viewModel.recordedDays, [5, 20])
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail（コンパイルエラー必至なので red 実行は skip 可）**
+
+`recordedDays` / `loadRecordedDaysForDisplayedMonth` / `startOfMonth` 未定義で `BUILD FAILED`。CLAUDE.md「red verification skip 条件 (a) コンパイルエラー確定」に該当するため skip。skip 理由は commit メッセージに明記。
+
+- [ ] **Step 3: Implement**（`RecordViewModel.swift`）
+
+`existingRecordCounts` の宣言（`var existingRecordCounts: [UUID: Int] = [:]`）の直後に追加:
+```swift
+    var displayedMonth: Date = RecordViewModel.startOfMonth(Date())
+    var recordedDays: Set<Int> = []
+```
+`private var loadCountsTask: Task<Void, Never>?` の直後に追加:
+```swift
+    private var loadRecordedDaysTask: Task<Void, Never>?
+```
+`normalizeToNoon` の直前（クラス末尾の private static 群の near）に追加:
+```swift
+    static func startOfMonth(_ date: Date) -> Date {
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.year, .month], from: date)
+        return cal.date(from: comps) ?? cal.startOfDay(for: date)
+    }
+
+    @MainActor
+    func loadRecordedDaysForDisplayedMonth() {
+        loadRecordedDaysTask?.cancel()
+
+        guard let child = selectedChild else {
+            recordedDays = []
+            return
+        }
+
+        let cal = Calendar.current
+        let monthStart = RecordViewModel.startOfMonth(displayedMonth)
+        guard let monthEnd = cal.date(byAdding: DateComponents(month: 1, second: -1), to: monthStart) else {
+            return
+        }
+
+        loadRecordedDaysTask = Task { [weak self] in
+            guard let self = self else { return }
+            do {
+                let records = try await self.helpRecordRepository.findByDateRange(from: monthStart, to: monthEnd)
+                guard !Task.isCancelled else { return }
+                let days = Set(
+                    records
+                        .filter { $0.childId == child.id }
+                        .map { cal.component(.day, from: $0.recordedAt) }
+                )
+                await MainActor.run {
+                    self.recordedDays = days
+                }
+            } catch {
+                // 取得失敗は無視 (UX 影響低・既存 errorMessage を上書きしない)
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -only-testing:OtetsudaiCoinTests/RecordViewModelTests/test_recordedDays_initiallyEmpty \
+  -only-testing:OtetsudaiCoinTests/RecordViewModelTests/test_loadRecordedDays_noSelectedChild_clearsSet \
+  -only-testing:OtetsudaiCoinTests/RecordViewModelTests/test_loadRecordedDays_filtersBySelectedChildAndMonth \
+  2>&1 | tee /tmp/issue84-test.log | tail -40
+```
+Expected: PASS（`Failing tests:` 無し）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
+git commit -m "feat(#84): recordedDays 算出と loadRecordedDaysForDisplayedMonth を追加
+
+選択中の子ども・表示中の月に記録がある日を Set<Int> で算出。
+findByDateRange + childId filter + day 抽出。取得失敗は無視 (既存 count と同方針)。
+red は型未定義のコンパイルエラー確定のため skip。
+
+Refs #84"
+```
+
+---
+
+## Task 2: ViewModel — 月移動と日選択
+
+**Files:**
+- Modify: `app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift`
+- Test: `app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift`
+
+- [ ] **Step 1: Write failing tests**（Task 1 のテスト群の直後に追記）
+
+```swift
+    @MainActor
+    func test_canGoToNextMonth_falseForCurrentMonth_trueForPast() {
+        let cal = Calendar.current
+        let today = cal.date(from: DateComponents(year: 2026, month: 6, day: 15))!
+
+        viewModel.displayedMonth = RecordViewModel.startOfMonth(today)
+        XCTAssertFalse(viewModel.canGoToNextMonth(today: today))
+
+        viewModel.displayedMonth = cal.date(from: DateComponents(year: 2026, month: 4, day: 1))!
+        XCTAssertTrue(viewModel.canGoToNextMonth(today: today))
+    }
+
+    @MainActor
+    func test_goToPreviousMonth_movesDisplayedMonthBack() {
+        let cal = Calendar.current
+        viewModel.displayedMonth = cal.date(from: DateComponents(year: 2026, month: 3, day: 1))!
+
+        viewModel.goToPreviousMonth()
+
+        XCTAssertEqual(
+            viewModel.displayedMonth,
+            cal.date(from: DateComponents(year: 2026, month: 2, day: 1))!
+        )
+    }
+
+    @MainActor
+    func test_goToNextMonth_cappedAtCurrentMonth() {
+        let cal = Calendar.current
+        let today = cal.date(from: DateComponents(year: 2026, month: 6, day: 15))!
+
+        // 過去月からは進める
+        viewModel.displayedMonth = cal.date(from: DateComponents(year: 2026, month: 4, day: 1))!
+        viewModel.goToNextMonth(today: today)
+        XCTAssertEqual(viewModel.displayedMonth, cal.date(from: DateComponents(year: 2026, month: 5, day: 1))!)
+
+        // 今日の月で頭打ち (no-op)
+        viewModel.displayedMonth = RecordViewModel.startOfMonth(today)
+        viewModel.goToNextMonth(today: today)
+        XCTAssertEqual(viewModel.displayedMonth, RecordViewModel.startOfMonth(today))
+    }
+
+    @MainActor
+    func test_selectDay_setsRecordedDateNoon_ignoresFuture() {
+        let cal = Calendar.current
+        let today = cal.date(from: DateComponents(year: 2026, month: 6, day: 15))!
+        viewModel.displayedMonth = RecordViewModel.startOfMonth(today)
+
+        // 過去日は選択され noon 正規化される
+        viewModel.selectDay(10, today: today)
+        let comps = cal.dateComponents([.year, .month, .day, .hour], from: viewModel.recordedDate)
+        XCTAssertEqual(comps.year, 2026)
+        XCTAssertEqual(comps.month, 6)
+        XCTAssertEqual(comps.day, 10)
+        XCTAssertEqual(comps.hour, 12)
+
+        // 未来日 (16) は無視され recordedDate は 10 のまま
+        viewModel.selectDay(16, today: today)
+        XCTAssertEqual(cal.component(.day, from: viewModel.recordedDate), 10)
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail（コンパイルエラー確定のため skip 可）**
+
+`canGoToNextMonth` / `goToPreviousMonth` / `goToNextMonth` / `selectDay` 未定義で `BUILD FAILED`。red skip、理由を commit に明記。
+
+- [ ] **Step 3: Implement**（`RecordViewModel.swift`、`loadRecordedDaysForDisplayedMonth` の直後）
+
+```swift
+    func canGoToNextMonth(today: Date = Date()) -> Bool {
+        displayedMonth < RecordViewModel.startOfMonth(today)
+    }
+
+    @MainActor
+    func goToPreviousMonth() {
+        let cal = Calendar.current
+        guard let prev = cal.date(byAdding: .month, value: -1, to: displayedMonth) else { return }
+        displayedMonth = RecordViewModel.startOfMonth(prev)
+        loadRecordedDaysForDisplayedMonth()
+    }
+
+    @MainActor
+    func goToNextMonth(today: Date = Date()) {
+        guard canGoToNextMonth(today: today) else { return }
+        let cal = Calendar.current
+        guard let next = cal.date(byAdding: .month, value: 1, to: displayedMonth) else { return }
+        displayedMonth = RecordViewModel.startOfMonth(next)
+        loadRecordedDaysForDisplayedMonth()
+    }
+
+    @MainActor
+    func selectDay(_ day: Int, today: Date = Date()) {
+        let cal = Calendar.current
+        var comps = cal.dateComponents([.year, .month], from: displayedMonth)
+        comps.day = day
+        guard let date = cal.date(from: comps) else { return }
+        // 未来日は無視 (View 側でも disabled だが二重防御)
+        if cal.startOfDay(for: date) > cal.startOfDay(for: today) { return }
+        recordedDate = RecordViewModel.normalizeToNoon(date)
+        // 旧 DatePicker .onChange 相当: 選択日の per-task 件数 (#73) を更新
+        loadExistingCountsForCurrentDateAndChild()
+    }
+```
+注: `normalizeToNoon` は既存 `private static`。同クラス内なので参照可。
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -only-testing:OtetsudaiCoinTests/RecordViewModelTests/test_canGoToNextMonth_falseForCurrentMonth_trueForPast \
+  -only-testing:OtetsudaiCoinTests/RecordViewModelTests/test_goToPreviousMonth_movesDisplayedMonthBack \
+  -only-testing:OtetsudaiCoinTests/RecordViewModelTests/test_goToNextMonth_cappedAtCurrentMonth \
+  -only-testing:OtetsudaiCoinTests/RecordViewModelTests/test_selectDay_setsRecordedDateNoon_ignoresFuture \
+  2>&1 | tee /tmp/issue84-test.log | tail -40
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
+git commit -m "feat(#84): 月移動 (canGo/go Previous/Next) と selectDay を追加
+
+displayedMonth を月単位で移動 (next は今日の月で頭打ち)。selectDay は noon 正規化で
+recordedDate をセットし未来日を無視、per-task 件数 reload も呼ぶ (旧 DatePicker onChange 相当)。
+today 注入で日付境界テストを決定的に (#112 学び)。red は型未定義で skip。
+
+Refs #84"
+```
+
+---
+
+## Task 3: ViewModel — reload trigger を data-lifecycle 入口に接続
+
+**Files:**
+- Modify: `app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift:110`（`loadData` 末尾）と `selectChild` 末尾
+- Test: `app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift`
+
+- [ ] **Step 1: Write failing test**（Task 2 群の直後）
+
+```swift
+    @MainActor
+    func test_selectChild_triggersRecordedDaysReload() async {
+        let cal = Calendar.current
+        func noon(_ d: Int) -> Date {
+            let base = RecordViewModel.startOfMonth(Date())
+            return cal.date(byAdding: DateComponents(day: d - 1, hour: 12), to: base)!
+        }
+        let childA = Child(id: UUID(), name: "A", themeColor: "#FF5733")
+        let childB = Child(id: UUID(), name: "B", themeColor: "#33FF57")
+        let task = HelpTask(id: UUID(), name: "皿洗い", isActive: true, coinRate: 10)
+        mockHelpTaskRepository.tasks = [task]
+        mockHelpRecordRepository.records = [
+            HelpRecord(id: UUID(), childId: childA.id, helpTaskId: task.id, recordedAt: noon(3)),
+            HelpRecord(id: UUID(), childId: childB.id, helpTaskId: task.id, recordedAt: noon(7)),
+            HelpRecord(id: UUID(), childId: childB.id, helpTaskId: task.id, recordedAt: noon(9)),
+        ]
+        // displayedMonth は init で当月。childA を選択 → {3}
+        viewModel.selectChild(childA)
+        await waitUntil(timeout: 2.0) { self.viewModel.recordedDays == [3] }
+
+        // When: childB に切替 → {7, 9}
+        viewModel.selectChild(childB)
+
+        // Then
+        await waitUntil(timeout: 2.0) { self.viewModel.recordedDays == [7, 9] }
+        XCTAssertEqual(viewModel.recordedDays, [7, 9])
+    }
+```
+
+- [ ] **Step 2: Run test to verify it FAILS（behavioral edge case — red を必ず実行）**
+
+reload trigger 未接続なら `selectChild(childA)` 後も `recordedDays` が空のままで `waitUntil` がタイムアウト → FAIL。CLAUDE.md「reload 経路など behavioral edge case の red は必ず実行」に従い実行する。
+
+Run:
+```bash
+xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -only-testing:OtetsudaiCoinTests/RecordViewModelTests/test_selectChild_triggersRecordedDaysReload \
+  2>&1 | tee /tmp/issue84-test.log | tail -40
+```
+Expected: FAIL（`Failing tests:` に当該テスト、waitUntil timeout）
+
+- [ ] **Step 3: Implement**（reload trigger 2 箇所）
+
+`loadData()` 末尾、既存 `loadExistingCountsForCurrentDateAndChild()`（`RecordViewModel.swift:110`）の直後に 1 行追加:
+```swift
+                setLoading(false)
+                loadExistingCountsForCurrentDateAndChild()
+                loadRecordedDaysForDisplayedMonth()   // ← 追加
+```
+
+`selectChild(_:)` 末尾、既存 `loadExistingCountsForCurrentDateAndChild()`（`selectChild` 内最終行）の直後に 1 行追加:
+```swift
+        clearErrorMessage()
+        loadExistingCountsForCurrentDateAndChild()
+        loadRecordedDaysForDisplayedMonth()   // ← 追加
+```
+
+注: `recordHelp` / `recordBulkHelp` には**追加しない**。記録保存後の反映は `notifyHelpRecordUpdated()` → observer → `loadData()` → `loadRecordedDaysForDisplayedMonth()` の既存 data-lifecycle 経路で行う（CLAUDE.md「reload trigger は data-lifecycle の入り口に集約」）。
+
+- [ ] **Step 4: Run test to verify it PASSES**
+
+Run（Step 2 と同じコマンド）。Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
+git commit -m "feat(#84): recordedDays reload を loadData/selectChild 末尾に接続
+
+reload trigger を data-lifecycle 入口に集約 (#73 学び)。記録保存後は
+notifyHelpRecordUpdated→observer→loadData 経路で反映するため write 操作内では呼ばない。
+behavioral red を実行して reload 未接続の fail を確認済み。
+
+Refs #84"
+```
+
+---
+
+## Task 4: `RecordCalendarView` コンポーネント
+
+**Files:**
+- Create: `app/OtetsudaiCoin/Presentation/Components/RecordCalendarView.swift`
+- Test: `app/OtetsudaiCoinTests/Presentation/Components/RecordCalendarViewTests.swift`
+
+設計メモ: `Image(systemName:)` を使わない（矢印は Text `‹` `›`）ため `AccessibilityImageLabel` blocker が発生せず、`accessibilityIdentifier` ベースのテストが安定する。グリッドは週単位の `VStack`+`HStack`（最大 6×7=42 セル、perf 影響なし、ViewInspector traversal が確実）。既存 `monthCalendarHeatmap` の `LazyVGrid` から意図的に逸脱（理由＝テスト容易性）。
+
+- [ ] **Step 1: Write failing component tests**（新規ファイル）
+
+`app/OtetsudaiCoinTests/Presentation/Components/RecordCalendarViewTests.swift`:
+```swift
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import OtetsudaiCoin
+
+@MainActor
+final class RecordCalendarViewTests: XCTestCase {
+
+    private let cal = Calendar.current
+
+    /// 2026-06 を表示月、今日=2026-06-15 とした標準セットアップ。
+    private func makeView(
+        recordedDays: Set<Int> = [],
+        selectedDay: Int? = nil,
+        onSelectDay: @escaping (Int) -> Void = { _ in },
+        onPrevMonth: @escaping () -> Void = {},
+        onNextMonth: @escaping () -> Void = {},
+        canGoNextMonth: Bool = false
+    ) -> RecordCalendarView {
+        let displayedMonth = cal.date(from: DateComponents(year: 2026, month: 6, day: 1))!
+        let today = cal.date(from: DateComponents(year: 2026, month: 6, day: 15))!
+        let selectedDate = selectedDay.flatMap {
+            cal.date(from: DateComponents(year: 2026, month: 6, day: $0, hour: 12))
+        } ?? cal.date(from: DateComponents(year: 2030, month: 1, day: 1))!  // 既定は表示月外
+        return RecordCalendarView(
+            displayedMonth: displayedMonth,
+            selectedDate: selectedDate,
+            recordedDays: recordedDays,
+            today: today,
+            canGoNextMonth: canGoNextMonth,
+            onSelectDay: onSelectDay,
+            onPrevMonth: onPrevMonth,
+            onNextMonth: onNextMonth
+        )
+    }
+
+    func test_recordDot_shownForRecordedDay_hiddenForOthers() throws {
+        let view = makeView(recordedDays: [5, 20])
+        let inspected = try view.inspect()
+        // 記録のある日 5,20 にはドット (identifier "record_dot_<day>")
+        XCTAssertNoThrow(try inspected.find(viewWithAccessibilityIdentifier: "record_dot_5"),
+                         "5日のドットが見つからない")
+        XCTAssertNoThrow(try inspected.find(viewWithAccessibilityIdentifier: "record_dot_20"),
+                         "20日のドットが見つからない")
+        // 記録の無い日 3 にはドットが無い
+        XCTAssertThrowsError(try inspected.find(viewWithAccessibilityIdentifier: "record_dot_3"),
+                             "3日に余計なドットがある")
+    }
+
+    func test_tapDay_callsOnSelectDayWithDay() throws {
+        var tapped: Int?
+        let view = makeView(onSelectDay: { tapped = $0 })
+        try view.inspect().find(viewWithAccessibilityIdentifier: "calendar_day_10").button().tap()
+        XCTAssertEqual(tapped, 10, "タップした 10日 が onSelectDay に渡らなかった")
+    }
+
+    func test_futureDay_buttonDisabled() throws {
+        // today=6/15。16日は未来なので disabled。
+        let view = makeView()
+        let dayButton = try view.inspect().find(viewWithAccessibilityIdentifier: "calendar_day_16").button()
+        XCTAssertTrue(try dayButton.isDisabled(), "未来日(16)が disabled になっていない")
+        // 過去日 10 は enabled
+        let past = try view.inspect().find(viewWithAccessibilityIdentifier: "calendar_day_10").button()
+        XCTAssertFalse(try past.isDisabled(), "過去日(10)が誤って disabled")
+    }
+
+    func test_nextMonthButton_disabledWhenCannotGoNext() throws {
+        let view = makeView(canGoNextMonth: false)
+        let next = try view.inspect().find(viewWithAccessibilityIdentifier: "calendar_next_month").button()
+        XCTAssertTrue(try next.isDisabled(), "canGoNextMonth=false で次月ボタンが disabled でない")
+    }
+
+    func test_tapPrevMonth_callsOnPrevMonth() throws {
+        var called = false
+        let view = makeView(onPrevMonth: { called = true })
+        try view.inspect().find(viewWithAccessibilityIdentifier: "calendar_prev_month").button().tap()
+        XCTAssertTrue(called, "前月ボタンのタップで onPrevMonth が呼ばれない")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail（型未定義のコンパイルエラー確定のため skip 可）**
+
+`RecordCalendarView` 未定義で `BUILD FAILED`。red skip、理由を commit に明記。
+
+- [ ] **Step 3: Implement**（新規ファイル）
+
+`app/OtetsudaiCoin/Presentation/Components/RecordCalendarView.swift`:
+```swift
+import SwiftUI
+
+/// 記録画面の「記録日」用インライン月カレンダー。
+/// 選択中の子どもの記録がある日に緑ドットを表示し、記録漏れ・二重登録に事前に気づけるようにする (#84)。
+/// 純プレゼンテーショナル: 状態は引数、操作はクロージャで親 (RecordView/RecordViewModel) に委譲。
+/// `Image(systemName:)` を使わず AccessibilityImageLabel blocker を避ける設計。
+struct RecordCalendarView: View {
+    let displayedMonth: Date      // 表示中の月 (月初アンカー)
+    let selectedDate: Date        // 選択中の記録日
+    let recordedDays: Set<Int>    // displayedMonth 内で記録がある日
+    let today: Date               // 未来日判定の基準
+    let canGoNextMonth: Bool
+    let onSelectDay: (Int) -> Void
+    let onPrevMonth: () -> Void
+    let onNextMonth: () -> Void
+
+    private let cal = Calendar.current
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            weekdayHeader
+            ForEach(Array(weeks.enumerated()), id: \.offset) { _, week in
+                HStack(spacing: 4) {
+                    ForEach(Array(week.enumerated()), id: \.offset) { _, day in
+                        if let day {
+                            dayCell(day)
+                        } else {
+                            Color.clear.frame(maxWidth: .infinity).frame(height: 38)
+                        }
+                    }
+                }
+            }
+            selectedCaption
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Button(action: onPrevMonth) {
+                Text("‹").font(.title2).frame(width: 44, height: 32)
+            }
+            .accessibilityIdentifier("calendar_prev_month")
+            .accessibilityLabel(Text(String(localized: "前の月")))
+
+            Spacer()
+            Text(monthTitle).appFont(.sectionHeader)
+            Spacer()
+
+            Button(action: onNextMonth) {
+                Text("›").font(.title2).frame(width: 44, height: 32)
+                    .opacity(canGoNextMonth ? 1 : 0.3)
+            }
+            .disabled(!canGoNextMonth)
+            .accessibilityIdentifier("calendar_next_month")
+            .accessibilityLabel(Text(String(localized: "次の月")))
+        }
+    }
+
+    private var weekdayHeader: some View {
+        HStack(spacing: 4) {
+            ForEach(orderedWeekdaySymbols, id: \.self) { sym in
+                Text(sym)
+                    .font(.caption2)
+                    .foregroundColor(AccessibilityColors.textSecondary)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    // MARK: - Day cell
+
+    private func dayCell(_ day: Int) -> some View {
+        let isRecorded = recordedDays.contains(day)
+        let isSelected = selectedDayInDisplayedMonth == day
+        let isFuture = isFutureDay(day)
+        return Button {
+            onSelectDay(day)
+        } label: {
+            VStack(spacing: 2) {
+                Text("\(day)")
+                    .font(.system(size: 15))
+                    .foregroundColor(dayForeground(isFuture: isFuture, isSelected: isSelected))
+                    .frame(width: 30, height: 30)
+                    .background {
+                        if isSelected {
+                            Circle().fill(AccessibilityColors.primaryBlue)
+                        }
+                    }
+                Circle()
+                    .fill(isRecorded ? AccessibilityColors.successGreen : Color.clear)
+                    .frame(width: 6, height: 6)
+                    .accessibilityIdentifier(isRecorded ? "record_dot_\(day)" : "")
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .disabled(isFuture)
+        .accessibilityIdentifier("calendar_day_\(day)")
+        .accessibilityLabel(Text(dayAccessibilityLabel(day, isRecorded: isRecorded, isSelected: isSelected, isFuture: isFuture)))
+    }
+
+    private func dayForeground(isFuture: Bool, isSelected: Bool) -> Color {
+        if isFuture { return AccessibilityColors.textDisabled }
+        if isSelected { return .white }
+        return AccessibilityColors.textPrimary
+    }
+
+    private var selectedCaption: some View {
+        HStack(spacing: 6) {
+            Text(String(localized: "記録日")).appFont(.secondaryInfo)
+                .foregroundColor(AccessibilityColors.textSecondary)
+            Text(selectedDate, format: .dateTime.year().month().day())
+                .appFont(.secondaryInfo)
+        }
+        .padding(.top, 2)
+    }
+
+    // MARK: - Derived data
+
+    private var monthTitle: String {
+        let f = DateFormatter()
+        f.locale = .current
+        f.setLocalizedDateFormatFromTemplate("yMMMM")
+        return f.string(from: displayedMonth)
+    }
+
+    private var orderedWeekdaySymbols: [String] {
+        let symbols = cal.shortWeekdaySymbols          // index 0 = Sunday
+        let first = cal.firstWeekday - 1
+        return Array(symbols[first...] + symbols[..<first])
+    }
+
+    /// 週ごとに分割した日番号 (前方の空白は nil)。
+    private var weeks: [[Int?]] {
+        guard let range = cal.range(of: .day, in: .month, for: displayedMonth) else { return [] }
+        let firstWeekday = cal.component(.weekday, from: displayedMonth) // 1=Sun..7=Sat
+        let leading = (firstWeekday - cal.firstWeekday + 7) % 7
+        var cells: [Int?] = Array(repeating: nil, count: leading)
+        cells.append(contentsOf: range.map { Optional($0) })
+        while cells.count % 7 != 0 { cells.append(nil) }
+        return stride(from: 0, to: cells.count, by: 7).map { Array(cells[$0 ..< $0 + 7]) }
+    }
+
+    /// selectedDate が displayedMonth と同じ年月なら、その日。違えば nil (ハイライトしない)。
+    private var selectedDayInDisplayedMonth: Int? {
+        let d = cal.dateComponents([.year, .month, .day], from: selectedDate)
+        let m = cal.dateComponents([.year, .month], from: displayedMonth)
+        return (d.year == m.year && d.month == m.month) ? d.day : nil
+    }
+
+    private func isFutureDay(_ day: Int) -> Bool {
+        var comps = cal.dateComponents([.year, .month], from: displayedMonth)
+        comps.day = day
+        guard let date = cal.date(from: comps) else { return false }
+        return cal.startOfDay(for: date) > cal.startOfDay(for: today)
+    }
+
+    private func dayAccessibilityLabel(_ day: Int, isRecorded: Bool, isSelected: Bool, isFuture: Bool) -> String {
+        let month = cal.component(.month, from: displayedMonth)
+        var parts = ["\(month)\(String(localized: "月"))\(day)\(String(localized: "日"))"]
+        parts.append(isRecorded ? String(localized: "記録あり") : String(localized: "記録なし"))
+        if isSelected { parts.append(String(localized: "選択中")) }
+        if isFuture { parts.append(String(localized: "選択できません")) }
+        return parts.joined(separator: "、")
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -only-testing:OtetsudaiCoinTests/RecordCalendarViewTests \
+  2>&1 | tee /tmp/issue84-test.log | tail -50
+```
+Expected: 全 5 テスト PASS。
+（万一 `find(viewWithAccessibilityIdentifier:)` が VStack/HStack 階層で到達不可なら、CLAUDE.md「SwiftUI View テスト戦略」に従い `findAll(ViewType.Button.self)` でボタンを列挙し day-number Text でフィルタする方式へ切替え、assertion message に観測ボタン数を dump して原因を可視化する。）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/OtetsudaiCoin/Presentation/Components/RecordCalendarView.swift app/OtetsudaiCoinTests/Presentation/Components/RecordCalendarViewTests.swift
+git commit -m "feat(#84): RecordCalendarView コンポーネントを追加
+
+選択中の子どもの記録がある日を緑ドット表示するインライン月カレンダー。
+日タップで onSelectDay、未来日と次月(canGoNextMonth=false)は disabled、各セルに
+a11y ラベル。Image(systemName:) を使わず blocker 回避、グリッドは週単位 VStack/HStack
+(既存 heatmap の LazyVGrid からテスト容易性のため意図的逸脱)。red は型未定義で skip。
+
+Refs #84"
+```
+
+---
+
+## Task 5: `RecordView` への統合
+
+**Files:**
+- Modify: `app/OtetsudaiCoin/Presentation/Views/RecordView.swift:132-154`（`dateSection`）と `:149-151`（旧 onChange）
+
+- [ ] **Step 1: 旧 `dateSection` を置換**
+
+`RecordView.swift` の `dateSection`（現在 `HStack` + `Image(systemName: "calendar")` + `DatePicker`、132〜154 行）を以下に置換:
+```swift
+    private var dateSection: some View {
+        RecordCalendarView(
+            displayedMonth: viewModel.displayedMonth,
+            selectedDate: viewModel.recordedDate,
+            recordedDays: viewModel.recordedDays,
+            today: Date(),
+            canGoNextMonth: viewModel.canGoToNextMonth(),
+            onSelectDay: { viewModel.selectDay($0) },
+            onPrevMonth: { viewModel.goToPreviousMonth() },
+            onNextMonth: { viewModel.goToNextMonth() }
+        )
+        .padding(.horizontal)
+    }
+```
+注: 旧 `DatePicker` 内の `.onChange(of: viewModel.recordedDate) { viewModel.loadExistingCountsForCurrentDateAndChild() }` は `selectDay` 内に移したため、この置換で自然に消える（二重 reload を避ける）。`dateSection` 以外に `recordedDate` の `.onChange` が残っていないことを `grep -n "onChange(of: viewModel.recordedDate)" app/OtetsudaiCoin/Presentation/Views/RecordView.swift` で確認（0 件であること）。
+
+- [ ] **Step 2: ビルド & 全テスト実行**
+
+Run:
+```bash
+xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -only-testing:OtetsudaiCoinTests/RecordViewModelTests \
+  -only-testing:OtetsudaiCoinTests/RecordCalendarViewTests \
+  2>&1 | tee /tmp/issue84-test.log | tail -50
+```
+Expected: PASS（`** TEST FAILED` 無し）
+
+- [ ] **Step 3: Simulator 視覚確認**（REQUIRED SUB-SKILL: `ios-simulator-app-verification`）
+
+`--uitesting` で太郎/花子 が seed される。Record タブを開きカレンダーが表示されること、記録のある日にドット、未来日が淡色、`‹` で前月へ移動できることをスクショで確認。`selectedTab` は `@State`（永続化なし）で simctl から Record タブへ切替不可のため、確認は (a) XCUITest で `app.tabBars.buttons.element(boundBy: 1)` をタップしてスクショ、または (b) 手動確認。plan 実行者は (a) を優先し、不可なら PR description に「Record タブは手動確認推奨」と明記。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/OtetsudaiCoin/Presentation/Views/RecordView.swift
+git commit -m "feat(#84): RecordView の DatePicker を RecordCalendarView に置換
+
+記録日エリアをインライン月カレンダーに。recordedDate onChange は selectDay 内へ移設し
+二重 reload を回避。
+
+Refs #84"
+```
+
+---
+
+## Task 6: 全体テスト & PR
+
+- [ ] **Step 1: フルテストスイート実行**（regression 確認）
+
+Run:
+```bash
+xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  2>&1 | tee /tmp/issue84-full.log | tail -60
+```
+Expected: 全 PASS。UI/load 系が flaky に落ちたら該当を `-only-testing:` で isolated 再実行し parallel flake を切り分け（CLAUDE.md「iOS テスト flake 切り分け」）。`grep -F "** TEST FAILED" /tmp/issue84-full.log` が空であること。
+
+- [ ] **Step 2: requesting-code-review**（REQUIRED SUB-SKILL: `superpowers:requesting-code-review`）
+
+- [ ] **Step 3: PR 作成前チェック**（CLAUDE.md Git/PR ルール）
+
+```bash
+git status --short --branch                          # HEAD ブランチ再確認
+gh pr list --head feat/issue-84-recorded-days-calendar   # 既存 PR の二重作成防止
+git fetch origin && git log --oneline feat/issue-84-recorded-days-calendar..origin/main | head  # main 進行確認
+```
+
+- [ ] **Step 4: PR 作成**
+
+```bash
+gh pr create --base main --head feat/issue-84-recorded-days-calendar \
+  --title "feat(#84): 記録日カレンダーで記録のある日を可視化" \
+  --body "$(cat <<'EOF'
+## 概要
+記録画面の記録日を、選択中の子どもの記録がある日を緑ドットで示すインライン月カレンダーに置換 (#84)。記録漏れ・二重登録に登録前に気づけるようにする。
+
+## 設計 / Plan
+- spec: docs/superpowers/specs/2026-06-05-issue-84-recorded-days-calendar-design.md
+- plan: docs/superpowers/plans/2026-06-05-issue-84-recorded-days-calendar.md
+
+## 主な変更
+- RecordViewModel: displayedMonth / recordedDays / loadRecordedDaysForDisplayedMonth / 月移動 / selectDay を追加。reload は data-lifecycle 入口に集約 (#73 学び)
+- RecordCalendarView (Components/) を新規追加。Image(systemName:) を使わず blocker を回避
+- RecordView の DatePicker を置換
+
+## テスト
+- ViewModel unit test 7 件 (記録日集合・月境界・月移動・選択・reload)
+- RecordCalendarView component test 5 件 (ドット表示・タップ・未来日/次月 disabled・前月タップ)
+- フルスイート PASS
+
+## Plan からの逸脱
+- (実行時に逸脱があればここに記載)
+
+Closes #84
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review（プラン作成者によるチェック — 完了済み）
+
+- **Spec coverage:** 受け入れ条件 8 項目すべてに対応タスクあり（カレンダー表示=T4/T5、ドット=T1/T4、未来日 disabled=T2/T4、月移動=T2/T4、タップ選択=T2/T4、記録後ドット反映=T3、a11y ラベル=T4、テスト green=T1-T6）。
+- **Placeholder scan:** TODO/TBD 無し。全コードステップに実コードを記載。
+- **Type consistency:** `displayedMonth`/`recordedDays`/`loadRecordedDaysForDisplayedMonth`/`canGoToNextMonth(today:)`/`goToPreviousMonth`/`goToNextMonth(today:)`/`selectDay(_:today:)`/`startOfMonth` の名称・シグネチャが ViewModel・View・テスト全タスクで一致。`RecordCalendarView` の引数（displayedMonth/selectedDate/recordedDays/today/canGoNextMonth/onSelectDay/onPrevMonth/onNextMonth）が T4 定義と T5 呼び出しで一致。accessibilityIdentifier（`calendar_day_<d>`/`record_dot_<d>`/`calendar_prev_month`/`calendar_next_month`）がコンポーネントとテストで一致。

--- a/docs/superpowers/specs/2026-06-05-issue-84-recorded-days-calendar-design.md
+++ b/docs/superpowers/specs/2026-06-05-issue-84-recorded-days-calendar-design.md
@@ -1,0 +1,172 @@
+# Issue #84: 記録登録時に「記録がある日」をカレンダーで可視化
+
+- Issue: [#84](https://github.com/es0612/OtetsudaiCoin/issues/84) お手伝い登録時にすでに記録がある日が見たい。記録漏れや二重登録に事前に気づける
+- 作成日: 2026-06-05
+- ステータス: 設計確定（ユーザーレビュー待ち）
+
+## 背景
+
+記録画面（`RecordView`, tab 1）の「記録日」は現在 `.compact` スタイルの `DatePicker` で、**どの日に記録があるかは日付を選んでみないと分からない**。そのため:
+
+- **記録漏れ**: つけ忘れた日（前後に記録があるのに空いている日）に気づきにくい。
+- **二重登録**: その日に既に記録済みかどうかは、日を選んでタスクカードのバッジ（#73）を見るまで分からない。
+
+ユーザーは「登録の前に、月全体を俯瞰して記録の有無を見たい」と要望している。
+
+### #73 との違い（既実装の確認済み）
+
+`git log --since=<#84 createdAt> -- RecordView/RecordViewModel` および `-S loadExistingCountsForCurrentDateAndChild` で既存実装を検証した結果、**#84 は #73 と補完関係にある別機能**であることを確認した。
+
+| | #73（実装済み） | #84（本 issue） |
+|---|---|---|
+| 何を見せる | 選択中の「その日」の各タスク既存記録**件数** | 「どの日」に記録があるか（月全体） |
+| どこに出る | `TaskCardView` のバッジ（`existingCount`） | 日付選択（カレンダー）のレベル |
+| いつ気づく | 日を選んだ**後** | 日を選ぶ**前**に俯瞰して |
+| 防ぐ | 同じ日・同タスクの二重登録 | 記録**漏れ** ＋ 二重登録 |
+
+データ層（`helpRecordRepository.findByDateRange(from:to:)`）と per-child 件数集約の前例は #73 で既にあり、再利用できる。
+
+## 製品判断（確定）
+
+ブレストのビジュアル比較（`.superpowers/brainstorm/` のモックアップ）で以下を確定:
+
+| 軸 | 結論 |
+|---|---|
+| 可視化方式 | **Option A: インライン月カレンダー**（`.compact` DatePicker を置換） |
+| マーカー | **ドット**（記録の「有無」のみ。件数は出さない。データは `Set<日>`） |
+| レイアウト | **インライン常時表示**（タップ不要で俯瞰が目に入る＝「事前に気づく」に最も忠実。画面高 +約160pt は許容） |
+| マーク対象 | **選択中の子ども 1 人分**の記録（#73 の per-child と一貫） |
+| 未来日 | **選択不可**（既存 `in: ...Date()` を踏襲、今日まで） |
+| 月移動 | **過去方向のみ**（記録漏れ補完のため）。今日を含む月より先へは進めない |
+
+### なぜ標準 `DatePicker(.graphical)` を使わないか
+
+SwiftUI 標準の `DatePicker(.graphical)` は各日へドット等の装飾を付ける API を持たない。マーカー表示には**カスタムの月グリッド**が必須。幸い既存 `MonthlyRetrospectiveView.monthCalendarHeatmap`（7 列 `LazyVGrid` の月ヒートマップ）と同じパターンで描けるため、ゼロからの発明にはならない。
+
+## スコープ外（本 issue では着手しない）
+
+- 既存 `monthCalendarHeatmap`（`MonthlyRetrospectiveView`）の共通コンポーネント化リファクタ。`MonthlyRetrospectiveView` に触れると #84 のスコープを越える。**パターンを真似るのみ**。統合に価値があれば別 issue を立てる（out-of-scope-finding ルール）。
+- 家族全員（複数子ども）の記録を 1 カレンダーに重畳する俯瞰ビュー。
+- 件数バッジ表示（ドットで確定）。
+- 記録済み日タップ時の追加警告ダイアログ（per-task の二重登録警告は #73 の `TaskCardView` バッジで担保済み）。
+
+## 設計
+
+### コンポーネント
+
+新規プレゼンテーショナル・コンポーネントを `Presentation/Components/` に切り出す（`RecordButtonBar` / `TaskCardView` / `ChildCardView` の前例に揃える）。ViewModel から状態を受け取り、操作はクロージャで上げる純表示コンポーネントにすることで **ViewInspector の NavigationStack+ScrollView+BannerAdView traversal 制約**（#74/#106）を回避し、コンポーネント単独でテスト可能にする。
+
+```
+RecordCalendarView  (Presentation/Components/RecordCalendarView.swift)
+  入力:
+    displayedMonth: Date          // 表示中の月のアンカー（月初）
+    selectedDate: Date            // 選択中の記録日（recordedDate）
+    recordedDays: Set<Int>        // displayedMonth 内で記録がある日(d)の集合（選択中の子ども分）
+    today: Date                   // 未来日判定の基準（テスト注入のため引数化）
+    canGoNextMonth: Bool          // 今日を含む月より先へ進めるか（常に false 想定だが計算は ViewModel）
+  操作（クロージャ）:
+    onSelectDay: (Int) -> Void    // 日タップ → その日を recordedDate に
+    onPrevMonth: () -> Void
+    onNextMonth: () -> Void
+```
+
+- ヘッダー: `‹  2026年 6月  ›`（`onPrevMonth`/`onNextMonth`。`canGoNextMonth == false` のとき `›` を disabled 表示）。
+- グリッド: 7 列 `LazyVGrid`。曜日ヘッダー（日〜土）＋ 月初の曜日オフセット分の空セル ＋ 各日セル。
+- 日セル: 日番号 ＋ `recordedDays.contains(d)` なら緑ドット。`selectedDate` の日なら塗り丸ハイライト。未来日（`displayedMonth` が今日の月かつ `d > 今日の日`）は淡色＋タップ無効。
+- ヘッダー下に小キャプション `記録日: M月D日` を表示（月をナビゲートして選択日が画面外でも、記録対象日を常に明示し誤記録を防ぐ）。
+
+`RecordView.dateSection` の `DatePicker` を本コンポーネントに置換する。
+
+### ViewModel（`RecordViewModel`）の追加状態とロジック
+
+ロジックはすべて ViewModel 側に置き unit-test 可能にする（コンポーネントは表示のみ）。
+
+```swift
+// 追加状態
+var displayedMonth: Date = Self.startOfMonth(Date())   // 月初アンカー
+var recordedDays: Set<Int> = []                        // displayedMonth 内・選択中の子の記録がある日
+
+// 追加メソッド
+func loadRecordedDaysForDisplayedMonth()   // displayedMonth と selectedChild から Set<Int> を算出
+func goToPreviousMonth()                    // displayedMonth を 1 ヶ月戻す → 再ロード
+func goToNextMonth()                        // 今日の月まで・それ以上は no-op → 再ロード
+func canGoToNextMonth() -> Bool             // displayedMonth < 今日の月 のとき true
+func selectDay(_ day: Int)                  // displayedMonth の day を recordedDate に（noon 正規化、未来日は無視）
+```
+
+- `loadRecordedDaysForDisplayedMonth()` は `helpRecordRepository.findByDateRange(from: 月初, to: 月末)` を引き、`childId == selectedChild` で filter、`Calendar.current.component(.day, from: recordedAt)` で日番号へ写像して `Set<Int>` を作る。`selectedChild == nil` のときは空集合。既存 `loadExistingCountsForCurrentDateAndChild()` と同じ非同期 + `loadCountsTask` 相当のキャンセル方式に揃える（専用 `Task` ハンドルを別に持つ）。
+- 既存 `existingRecordCounts`（per-task 件数）とは**別の集約**（per-day 有無）。混ぜない。
+- `selectDay` は `normalizeToNoon` を使い `recordedDate` を更新。これにより既存 `dateSection` の `onChange(recordedDate)` 経路で per-task `existingRecordCounts` も連動更新される。
+
+### データフロー（reload trigger の集約 — #73 学び）
+
+`recordedDays` の再ロードは **data-lifecycle の入口にのみ**置く。`recordHelp` / `recordBulkHelp` の中では絶対に呼ばない（`setLoading(true)` が `errorMessage` をクリアする副作用の罠を回避）。
+
+| トリガ | 理由 |
+|---|---|
+| `loadData()` 末尾 | 初期ロード／`notifyHelpRecordUpdated` observer 経由の再取得時。既存 `loadExistingCountsForCurrentDateAndChild()` の直後に `loadRecordedDaysForDisplayedMonth()` を追加 |
+| `selectChild()` 末尾 | 子ども切替で対象記録が変わる（既存 count reload と同じ場所） |
+| `displayedMonth` 変更（`goToPreviousMonth`/`goToNextMonth` 内） | 表示月が変わったら当月分を引き直す |
+| `notifyHelpRecordUpdated` observer | 記録保存後の反映。observer は既に `loadData()` を呼ぶので、↑の `loadData` 末尾追加で自動的にカバー（新規 dot が出る） |
+
+→ 記録直後に新しい日へドットが付くのは `recordHelp`→`notifyHelpRecordUpdated()`→observer→`loadData()`→`loadRecordedDaysForDisplayedMonth()` の既存 data-lifecycle 経路で実現。write 操作内で直接 reload しない。
+
+### 月移動と選択日の関係
+
+- `displayedMonth` はナビゲーション状態、`recordedDate`（=selectedDate）は選択状態で独立。
+- 過去月へナビゲートしても `recordedDate` は変わらない。選択丸ハイライトは `recordedDate` がその月にあるときだけ表示。
+- ヘッダー下キャプション `記録日: M月D日` で記録対象を常に明示し、月を移動して選択日が画面外でも誤記録を防ぐ。
+- 記録ボタンは従来どおり `recordedDate` を対象に保存。
+
+### エラー処理
+
+`loadRecordedDaysForDisplayedMonth()` の取得失敗は **無視**（`recordedDays` を据え置き、`errorMessage` を上書きしない）。既存 `loadExistingCountsForCurrentDateAndChild()` の `catch` 方針（UX 影響低・既存エラーを潰さない）に一致させる。
+
+### アクセシビリティ
+
+標準 DatePicker の VoiceOver を失うため、各日セルに明示ラベルを付ける:
+
+- `accessibilityLabel`: `"6月3日"`（＋ 状態 `"記録あり"` / `"記録なし"`、選択中なら `"選択中"`、未来日なら `"選択できません"`）。
+- 月移動 `‹ ›` ボタンにもラベル（`"前の月"` / `"次の月"`）。
+- 色（緑ドット）は `AccessibilityColors` を使用し、有無は色だけでなくラベルでも伝える。
+
+### i18n
+
+新規文字列はすべて `String(localized:)` 経由。対象: 月ラベル（`DateFormatter` の locale 連動 or `String(localized:)`）、曜日ヘッダー、`記録日: …` キャプション、アクセシビリティラベル、前/次の月ボタン。`%lld` 系の件数文字列は本機能では不要（ドットのみ）。
+
+## テスト戦略
+
+ViewInspector の制約（RecordView 本体は NavigationStack+ScrollView+BannerAdView で深く traverse 不可）を踏まえ、以下で担保:
+
+1. **ViewModel unit test**（ロジックの中核）
+   - `recordedDays` 算出: 指定月に複数子の記録がある状態で、選択中の子の記録日のみが日番号集合に入る（他child除外）。
+   - 月境界: 月初/月末の記録が正しく当月集合に入る／隣月の記録が混入しない（#112 の日付境界 flake 学びに留意し `today` を注入してテスト決定的に）。
+   - `canGoToNextMonth()`: 今日の月で false、過去月で true。
+   - `goToPreviousMonth`/`goToNextMonth` が `displayedMonth` を正しく移動し、next は今日の月で頭打ち。
+   - `selectDay(d)` が `recordedDate` を noon 正規化で更新し、未来日は無視。
+   - reload trigger: `selectChild` 後に `recordedDays` が対象児童分へ更新される。
+2. **コンポーネント behavior test**（`RecordCalendarView` 単独）
+   - 日タップで `onSelectDay` が正しい日で呼ばれる。
+   - `canGoNextMonth == false` で `›` が disabled（`find(ViewType.Button.self)` 経由で state 確認。`AccessibilityImageLabel` blocker 回避のため identifier 依存にしない）。
+   - `recordedDays` に含まれる日にマーカー要素が描画される（`findAll(ViewType.Text.self)` で blocker を跨いで観測、assertion message に観測値を dump して未検証 traversal を可視化＝#106 学び）。
+3. RecordView 本体の構造テストは**書かない**。最終 visual は simulator 手動 / 既存 ASC スクショ系で確認。
+
+## 受け入れ条件
+
+- [ ] 記録画面の「記録日」がインライン月カレンダーになっている。
+- [ ] 選択中の子どもの記録がある日に緑ドットが表示される（他の子の記録は出ない）。
+- [ ] 今日より未来の日は淡色で選択できない。
+- [ ] `‹` で過去月へ移動でき、`›` は今日を含む月で無効。
+- [ ] 日をタップするとその日が記録日（青丸ハイライト）になり、記録ボタンでその日に保存される。
+- [ ] 記録直後、保存した日へドットが付く（observer→loadData 経路）。
+- [ ] 各日セル・月移動ボタンにアクセシビリティラベルがある。
+- [ ] ViewModel テストとコンポーネント behavior テストが green。
+
+## 関連
+
+- Issue #73（PR で実装済み）— per-task 既存記録件数バッジ。本機能と補完関係。
+- `MonthlyRetrospectiveView.monthCalendarHeatmap` — 月グリッドの既存パターン（真似る対象、改変しない）。
+- CLAUDE.md「NotificationManager 発火と error message の干渉」/「reload trigger は data-lifecycle の入り口に集約」（#73）。
+- CLAUDE.md「SwiftUI View テスト戦略」（#74/#106 のコンポーネント分離・blocker 回避）。
+- CLAUDE.md「テスト日付境界バグ」（#112、`today` 注入で決定的に）。
+- `superpowers:writing-plans` — 次工程（本 spec 承認後）。


### PR DESCRIPTION
## 概要
記録画面（記録タブ）の記録日 UI を、`.compact` DatePicker から **インライン月カレンダー**に置換しました (#84)。選択中の子どもが既に記録のある日に緑ドットを表示し、登録の前に「記録漏れ／二重登録」に俯瞰して気づけるようにします。

`#73`（タスクカードの per-task 件数バッジ）が「選択した日の各タスク件数」を見せるのに対し、本 PR は「**どの日**に記録があるか」を月レベルで可視化する補完機能です。

## 設計 / Plan
- 設計 spec: `docs/superpowers/specs/2026-06-05-issue-84-recorded-days-calendar-design.md`
- 実装 plan: `docs/superpowers/plans/2026-06-05-issue-84-recorded-days-calendar.md`
- ブレストで確定: Option A（インライン月カレンダー）/ ドットマーカー / 選択中の子ども 1 人分 / 未来日選択不可 / 過去月移動可

## 主な変更
- **RecordViewModel**: `displayedMonth` / `recordedDays: Set<Int>` と `loadRecordedDaysForDisplayedMonth()` / 月移動 (`goToPreviousMonth` / `goToNextMonth(today:)` / `canGoToNextMonth(today:)`) / `selectDay(_:today:)` を追加。reload trigger は **data-lifecycle 入口（`loadData` 末尾・`selectChild` 末尾）にのみ**集約し、`recordHelp`/`recordBulkHelp` には入れない（`setLoading(true)`→`errorMessage` クリアの罠回避 = #73 学び）。記録保存後のドット反映は `notifyHelpRecordUpdated`→observer→`loadData` の既存経路で行う。
- **RecordCalendarView**（新規 `Presentation/Components/`）: 純プレゼンテーショナルな月カレンダー。`Image(systemName:)` を使わず（矢印は Text `‹`/`›`）AccessibilityImageLabel blocker を回避、グリッドは週単位 VStack/HStack。各日セルに a11y ラベル付き。
- **RecordView**: `dateSection` の DatePicker を `RecordCalendarView` に置換。旧 `.onChange(of: recordedDate)` は `selectDay` 内へ移設（二重 reload 回避）。
- **Localizable.xcstrings**: 5 キーの英訳追加（前の月→Previous month / 次の月→Next month / 記録あり→Recorded / 記録なし→Not recorded / 選択できません→Unavailable）。

## テスト
- **RecordViewModel unit test**（記録日集合の算出・月境界・年境界 Dec↔Jan・月移動・selectDay・selectChild reload）
- **RecordCalendarView component test 6 件**（ドット表示の有無・選択リング・日タップ→onSelectDay・未来日/今日/過去日の disabled・次月 disabled・前月タップ）
- `OtetsudaiCoinTests` フルスイート **green**（`** TEST SUCCEEDED **`、failed 0 件）
- **視覚確認**: `capture-asc-screenshots.sh` で ja/en の記録タブを撮影し目視確認済み。今日(5日)が青丸選択、未来日グレーアウト、次月`›`無効、キャプション「記録日」が locale 対応（ja「2026年6月5日」/ en「Recorded date Jun 5, 2026」）。レイアウトのクリッピング無し。

## Plan からの逸脱
- **コンポーネントテストの lookup 方式**: plan は `find(viewWithAccessibilityIdentifier:)` を想定していたが、**ViewInspector 0.10.2 + iOS 26 SDK で accessibilityIdentifier 解決が systematic に効かない回帰**が判明。`findAll(ViewType.Button.self)` を Text 内容でフィルタ、ドット/選択リングは `findAll(ViewType.Shape.self)` + `fillShapeStyle(Color.self)` の色判定に切替えた（plan が想定した fallback の範囲内）。実は色を直接見るため識別子方式より強い検証になっている。
- **ドットの a11y**: plan の `record_dot_<day>` accessibilityIdentifier は上記回帰でデッドコード化するため、装飾ドットは `.accessibilityHidden(true)` とし、記録有無はセルの accessibilityLabel（記録あり/なし）で伝える（VoiceOver 体験が向上）。
- **a11y 日付ラベルの i18n**: ハードコードの「M月D日」を `.formatted(.dateTime.year().month().day())` に変更（locale 対応・割り当て削減）。
- **追加テスト**: レビュー駆動で「今日が選択可能」「選択リング表示」「年境界 nav」のアサーションを追加。

## 既知のカバレッジギャップ（軽微・非ブロッカー）
- 「記録保存→ドット出現」の observer 経路は NotificationCenter 往復のため直接 unit test せず、各リンク（selectChild reload / loadData が loadRecordedDays を呼ぶ）で**間接的に**担保。

## Out-of-scope findings / follow-ups（本 PR では対応しない）
- **ASC スクショの stale 化**: 本 PR で記録タブ UI が変わるため、committed の `docs/screenshots/asc/v1.1.x/{ja,en}/02-record.png`（旧 DatePicker）は merge 後 stale になる。**次回リリース時に `capture-asc-screenshots.sh` で再生成**する（release flow / #50 の領域。本 PR には混ぜない）。
- **iOS 26 ViewInspector 回帰**: `accessibilityIdentifier()` 解決不可の知見を CLAUDE.md「SwiftUI View テスト戦略」に追記 + Issue 化予定（別 follow-up）。
- **子ども名の en 表示**: en でも「太郎/花子」が日本語のまま（Core Data 保存値の既知 data-layer i18n = #89）。本 PR スコープ外。

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)