### PR TITLE
chore(#50): 英語 ASC メタデータの fastlane deliver scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,19 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 
+# fastlane ASC metadata delivery (asc-metadata-delivery skill)
+# Credentials — never commit
+fastlane/.env
+fastlane/.env.*
+# ASC review demo credentials & personal contact info — never commit
+# (notes.txt は「ログイン不要」の説明なのでコミット可)
+fastlane/metadata/review_information/demo_user.txt
+fastlane/metadata/review_information/demo_password.txt
+fastlane/metadata/review_information/first_name.txt
+fastlane/metadata/review_information/last_name.txt
+fastlane/metadata/review_information/email_address.txt
+fastlane/metadata/review_information/phone_number.txt
+
 .DS_Store
 
 # Claude Code plan-mode の自動生成成果物（使い捨て）

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,14 @@
+# fastlane Appfile — per-app ASC identity (asc-metadata-delivery skill)
+#
+# Only the bundle identifier is committed here (it is unambiguous).
+# The ASC LOGIN identity is intentionally NOT hardcoded — set it in the
+# uncommitted fastlane/.env as FASTLANE_USER (see fastlane/SETUP.md).
+app_identifier("com.asapapalab.OtetsudaiCoin")
+
+# Team IDs vary per Apple account and are required by some deliver operations.
+# Uncomment + fill in if `fastlane deliver` cannot auto-resolve (multiple teams):
+#   team_id     — Apple Developer Portal Team ID (10 chars, e.g. "ABCDE12345")
+#   itc_team_id — App Store Connect Team ID (numeric)
+# Find via: developer.apple.com/account (Membership) or `fastlane deliver init`.
+# team_id("XXXXXXXXXX")
+# itc_team_id("XXXXXXXXX")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,29 @@
+default_platform(:ios)
+
+# asc-metadata-delivery: metadata-only delivery.
+# バイナリは Xcode Cloud が所有する (このリポジトリでは fastlane でビルド/アップロードしない)。
+# 投入系 lane は人間が認証情報付きで手実行する前提。CI / subagent では自動実行しないこと。
+# 実行前に fastlane/SETUP.md の download-first フローと認証情報設定を必ず読むこと。
+platform :ios do
+  desc "Stage metadata-only to ASC editable, then precheck the staged copy"
+  lane :upload_metadata do
+    # 1) metadata を ASC の editable バージョンに stage する。
+    #    skip_binary_upload : バイナリは Xcode Cloud 所有なので触らない。
+    #    submit_for_review  : false = ステージのみ。審査提出は ASC UI で人間が行う。
+    #    skip_screenshots   : true  = スクショは deliver 管理外 (SETUP.md 参照)。
+    #                         live ASC のスクショを誤って消さないための防御。
+    #    force は付けない : 本番書き込み前に deliver の HTML プレビューを
+    #                       人間が確認する gate を意図的に残す。
+    upload_to_app_store(
+      skip_binary_upload: true,
+      submit_for_review: false,
+      skip_screenshots: true
+    )
+
+    # 2) precheck は ASC 側 (editable) を検証する (ローカルを指す metadata_path は無い)。
+    #    よって upload の後に呼び、いま stage したコピーを人間 submit 前に検証する。
+    #    en-emoji / version bump は precheck では拾えない。upload 前に
+    #    release-version-bump-check skill でローカル検査すること (SETUP.md 参照)。
+    precheck
+  end
+end

--- a/fastlane/SETUP.md
+++ b/fastlane/SETUP.md
@@ -1,0 +1,136 @@
+# fastlane metadata delivery — SETUP
+
+このリポジトリの fastlane は **App Store Connect (ASC) のテキストメタデータのみ**を投入するために使います。
+バイナリ (ipa) は **Xcode Cloud が所有**しており、fastlane ではビルド・アップロードしません。
+
+> スキル参照: グローバルスキル `asc-metadata-delivery`（仕組み）+ `release-version-bump-check`（upload 前のローカル検査）。
+
+## 0. これは何のためか（#50 Phase 1）
+
+ASC の **英語 (English U.S.) ロケーション**を追加するためのメタデータ scaffold です。
+日本語ロケーションは既に live のため、本リポジトリには **`metadata/en-US/` のドラフトのみ**を同梱しています
+（ja・copyright・category・URL などの非英語/非ローカライズ項目は live ASC から download して取得します。後述の download-first を参照）。
+
+英語ドラフトの出典: リポジトリ root の `RELEASE_v1.1.1_ASC_EN.md`。
+
+## 1. 前提ツール
+
+- fastlane（macOS, Homebrew 版で可: `fastlane --version` で確認。本 scaffold は 2.228.0 で検証）。
+- ASC 認証情報（下記 §2）。
+
+## 2. 認証情報（コミットしない）
+
+`fastlane/.env`（gitignore 済み）に設定します。いずれか:
+
+#### (A) Apple ID + App-Specific Password
+
+```ini
+FASTLANE_USER=<ASC ログインに使う Apple ID メール>
+FASTLANE_PASSWORD=<App-Specific Password (appleid.apple.com で発行)>
+```
+
+#### (B) App Store Connect API Key（推奨・2FA 不要）
+
+```ini
+# .env に key ファイルパス等を置くか、lane 実行時に --api_key_path で渡す
+APP_STORE_CONNECT_API_KEY_PATH=/absolute/path/to/AuthKey_XXXX.p8
+```
+
+> `apple_id`（ログイン identity）は `Appfile` にハードコードしていません（個人メール混入と
+> 「どのメールでログインするか」の曖昧さを避けるため）。必ず `.env` の `FASTLANE_USER` で指定してください。
+
+## 3. Appfile の team_id（必要なら）
+
+`fastlane/Appfile` は `app_identifier`（= `com.asapapalab.OtetsudaiCoin`）のみコミットしています。
+複数チームに所属していて `deliver` がチームを自動解決できない場合のみ、`Appfile` の
+`team_id` / `itc_team_id` をコメント解除して埋めてください（developer.apple.com の Membership で確認）。
+
+## 4. 投入フロー（**順序厳守**・人間が手実行）
+
+> ⚠️ **安全性**: `upload_to_app_store` は `submit_for_review:false` でも metadata を
+> **live ASC の editable バージョンに stage（書き込み）します**。`false` は「審査に出さない」だけで
+> 「ASC に書かない」ではありません。投入系コマンドは **CI / subagent では絶対に自動実行しない**でください。
+
+### 4-1. 🚧 HARD GATE: 先に download してから編集する
+
+**いきなり `upload_metadata` を実行しないでください。** 先に live ASC の現状を取得します:
+
+```bash
+cd <repo root>
+fastlane deliver download_metadata
+```
+
+理由（footgun）: `deliver` は metadata ディレクトリに**存在するロケールの各フィールド**を ASC へ書き込みます。
+`copyright` / `primary_category` / `support_url` などローカルに無いフィールドを **空で上書き**してしまう恐れがあります。
+download すると live の現在値（ja ロケール・copyright・category など）が `metadata/` に埋まり、上書き事故を防げます。
+本 scaffold が同梱する `metadata/en-US/` は download では取得されません（en ロケールはまだ ASC に無いため）＝**共存します**。
+
+### 4-2. 内容を確認・編集
+
+- `metadata/en-US/*.txt`（本 scaffold の英語ドラフト）を spot-review。
+- download で取得した `metadata/ja/*.txt` 等が意図通りか確認。
+
+### 4-3. upload 前のローカル検査（precheck では拾えない穴を潰す）
+
+`release-version-bump-check` skill を使い、**upload 前に**以下をローカルで検査:
+
+- **英語ロケールの emoji 禁止**（#85）: `metadata/en-US/` の Description / What's New に絵文字があると ASC が silent reject。
+  本 scaffold の英語ドラフトは絵文字なし（`¥` `—` は絵文字ではなく通貨/ダッシュ記号で OK）。
+- **version bump**（ITMS-90186 / 90062）: 本フローは metadata-only なので通常は無関係ですが、
+  もし同セッションでバイナリも更新するなら `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` の bump を確認。
+- **Age Rating「広告」= はい**（AdMob 統合のため。ASC UI で手動確認）。
+
+### 4-4. stage（書き込み）→ precheck
+
+```bash
+fastlane upload_metadata
+```
+
+この lane は `upload_to_app_store`（stage）→ `precheck`（ASC 側 staged コピーを検証）の順で走ります。
+`force` を付けていないため、**書き込み前に deliver の HTML プレビュー**が出ます。内容を必ず確認してから進めてください。
+`precheck` は placeholder / curse words / unreachable URL 等を ASC 側 editable に対して検査します。
+
+### 4-5. 人間が ASC UI で submit
+
+precheck まで緑なら、**ASC UI で「審査へ提出」を人間が行います**（lane は自動提出しません）。
+
+## 5. ⚠️ 人間が確認すべき未検証ポイント（このリポジトリでは検証不能）
+
+1. **en ロケールの新規作成**: `upload_to_app_store` が **en-US ロケーションを新規作成するか、既存ロケールの更新のみか**は
+   このリポジトリ側では検証できません。`deliver` が en を新規作成しない挙動だった場合は、
+   **先に ASC UI で English (U.S.) ロケーションを Add してから** `upload_metadata` を実行してください
+   （ASC → My Apps → おてつだいコイン → (バージョン) → Localizations → Add Language: English (U.S.)）。
+2. **download-first の遵守**: §4-1 の HARD GATE を飛ばすと非ローカライズ項目を空で上書きする恐れがあります。
+
+## 6. スクリーンショットは deliver 管理外（#50 §1.5 は未完）
+
+`upload_metadata` lane は `skip_screenshots: true` です（live スクショの誤削除を防ぐため）。
+英語ロケール用スクショ (`docs/screenshots/asc/v1.1.x/en/` に撮影済み) の ASC 反映は、
+**ASC UI での手動アップロード**、または将来 `screenshots_path` を設定した別 deliver 実行で行ってください。
+→ **#50 Phase 1 §1.5（英語スクショの ASC 反映）は本 scaffold では完了しません**。別途対応。
+
+## 7. ディレクトリ構成
+
+```text
+fastlane/
+├── Appfile                     # app_identifier のみ（team_id は任意）
+├── Fastfile                    # upload_metadata lane (stage → precheck)
+├── SETUP.md                    # この文書
+├── .env                        # 認証情報（gitignore・各自作成）
+└── metadata/
+    ├── en-US/                  # 英語ドラフト（本 scaffold が同梱）
+    │   ├── name.txt
+    │   ├── subtitle.txt
+    │   ├── description.txt
+    │   ├── keywords.txt
+    │   ├── promotional_text.txt
+    │   ├── release_notes.txt
+    │   ├── support_url.txt
+    │   └── privacy_url.txt
+    ├── ja/                     # download_metadata で live から取得（コミットしない運用）
+    ├── copyright.txt           # 同上（download で取得）
+    ├── primary_category.txt    # 同上（download で取得）
+    └── review_information/
+        ├── notes.txt           # ログイン不要の説明（コミット可）
+        └── demo_user.txt 等    # 機微情報 → gitignore
+```

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -1,0 +1,24 @@
+A fun way to support your child's chores at home — together as a family.
+
+[Main features]
+- Record chores with a single tap and earn coins
+- Register multiple children, each with a personal theme color
+- Customize the list of chores to match your home
+- Monthly history view with automatic allowance calculation
+- Monthly Retrospective screen — celebrate effort as a family
+- Backdate entries when you forget to log right away
+
+[What makes it different]
+- Simple, child-friendly design
+- Coin animations and sound effects to keep kids motivated
+- Fully offline — no internet connection required
+- All data stays on your device only
+
+Note for international users:
+Otetsudai Coin is designed primarily for Japanese-speaking families.
+The user interface is available in English, but the allowance amount
+is displayed in Japanese yen (¥) only. The app is well suited for
+Japanese families living abroad and bilingual households who want to
+maintain a Japanese-style chores-and-allowance routine.
+
+Help your child build great habits and bring your family closer — one chore at a time!

--- a/fastlane/metadata/en-US/keywords.txt
+++ b/fastlane/metadata/en-US/keywords.txt
@@ -1,0 +1,1 @@
+chores,allowance,kids,family,habit,routine,Japanese,bilingual,record,parenting

--- a/fastlane/metadata/en-US/name.txt
+++ b/fastlane/metadata/en-US/name.txt
@@ -1,0 +1,1 @@
+Otetsudai Coin

--- a/fastlane/metadata/en-US/privacy_url.txt
+++ b/fastlane/metadata/en-US/privacy_url.txt
@@ -1,0 +1,1 @@
+https://es0612.github.io/OtetsudaiCoin/privacy-policy.html

--- a/fastlane/metadata/en-US/promotional_text.txt
+++ b/fastlane/metadata/en-US/promotional_text.txt
@@ -1,0 +1,1 @@
+Stable home screen + English UI support. A great fit for Japanese-speaking families abroad and bilingual households building chores-and-allowance habits together.

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,0 +1,10 @@
+Version 1.1.1 brings a more stable home screen and improved English support.
+
+Bug fixes
+- Fixed an issue where your children's cards and stats sometimes failed to appear the first time the Home screen opened.
+- Fixed the "Version" row on the Settings screen so it now shows the current version (1.1.1) correctly instead of an outdated number.
+
+Improved English support
+- Tab labels (Home / Record / Settings), the Retrospective screen, each section of the Settings screen, notification settings, and the body text of reminder notifications now display naturally in English.
+
+Thank you for using Otetsudai Coin — we hope you keep enjoying it together with your family!

--- a/fastlane/metadata/en-US/subtitle.txt
+++ b/fastlane/metadata/en-US/subtitle.txt
@@ -1,0 +1,1 @@
+Build chore habits with kids

--- a/fastlane/metadata/en-US/support_url.txt
+++ b/fastlane/metadata/en-US/support_url.txt
@@ -1,0 +1,1 @@
+https://es0612.github.io/OtetsudaiCoin/

--- a/fastlane/metadata/review_information/notes.txt
+++ b/fastlane/metadata/review_information/notes.txt
@@ -1,0 +1,14 @@
+No sign-in or account is required to use this app.
+
+Otetsudai Coin is a fully offline app: all data (children, chores, records,
+allowance) is stored locally on the device only. There is no server, no login,
+and no demo account is needed for review.
+
+To exercise the main flow:
+1. Launch the app and complete (or skip) the brief tutorial.
+2. Add a child via the child-management screen if none exist.
+3. On the Record tab, pick the child and a date on the calendar, tap a chore
+   card, then "Record".
+4. Coins accumulate; the Home and monthly screens show history and allowance.
+
+The app integrates Google Mobile Ads (AdMob) with non-personalized ads only.


### PR DESCRIPTION
## 概要
App Store Connect の **English (U.S.) ロケーション追加 (#50 Phase 1)** を `fastlane deliver` 化する scaffold です。既存の英語ドラフト（`RELEASE_v1.1.1_ASC_EN.md`）を `fastlane/metadata/en-US/` に配置し、メタデータのみを ASC に stage できる lane / 設定 / 手順書を用意しました。**文章は新規生成していません**（既存ドラフトの転記）。

バイナリは Xcode Cloud が所有するため、本 lane は `skip_binary_upload:true` でメタデータのみを扱います。

## 主な変更
- `fastlane/metadata/en-US/*.txt`: name / subtitle / description / keywords / promotional_text / release_notes / support_url / privacy_url（英語ドラフト由来）
- `fastlane/Fastfile`: `upload_metadata` lane（`upload_to_app_store` で stage → `precheck`）。`skip_binary_upload:true` / `submit_for_review:false`（stage のみ）/ `skip_screenshots:true` / `force` 無し（書き込み前に HTML プレビュー gate）
- `fastlane/Appfile`: `app_identifier` のみ commit（login identity は `.env` の `FASTLANE_USER` で指定。個人メールをハードコードしない）
- `fastlane/SETUP.md`: 認証情報・**download-first HARD GATE**・投入フロー・人間確認項目・スクショ deferral を明記
- `fastlane/metadata/review_information/notes.txt`: ログイン不要の説明（コミット可）
- `.gitignore`: `.env` と review_information の機微ファイルを ignore

## 検証（認証情報なしで可能な範囲）
- `fastlane lanes` → `ios upload_metadata` が登録（Fastfile/Appfile パース成功・syntax エラーなし）
- en-US メタデータに **emoji なし**（#85 対応。`¥`/`—` は emoji 範囲外なので OK）
- ASC 文字数制限内: name 14 / subtitle 28（≤30）, keywords 78（≤100）, promotional_text 162（≤170）
- staged ファイルに secret 混入なし（`.env` / `demo_*` は gitignore）

## ⚠️ この PR では完了しないこと（#50 は close しない）
本 scaffold は「ASC へ投入する仕組み」までで、**実際の投入と submit は人間が認証情報付きで手実行**します（`deliver` は live ASC に書き込むため、CI/自動では走らせない設計）。残作業:
1. **`fastlane deliver download_metadata` を先に実行**（download-first HARD GATE）して ja・copyright・category 等を live から取得 → 非ローカライズ項目の空上書きを防ぐ
2. **en ロケールの新規作成**: `deliver` が en-US を新規作成しない挙動の場合、ASC UI で先に English (U.S.) を Add（SETUP.md §5 に明記）
3. **`fastlane upload_metadata`（stage）→ precheck → ASC UI で人間が submit**
4. **英語スクショ（#50 §1.5）の ASC 反映は未完**: lane は `skip_screenshots:true`。`docs/screenshots/asc/v1.1.x/en/` の撮影済み PNG は ASC UI 手動アップロード or 別 deliver 実行で対応
5. upload 前に `release-version-bump-check` skill で en-emoji / Age Rating「広告=はい」を再確認

## 関連
- 英語ドラフト出典: `RELEASE_v1.1.1_ASC_EN.md`
- スキル: `asc-metadata-delivery`（scaffold/配信機構）+ `release-version-bump-check`（upload 前ローカル検査）

Refs #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)