### PR TITLE
chore(#50): 英語 What's New を v1.1.3 へ更新（バージョン不整合の修正）

### DIFF
--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,10 +1,14 @@
-Version 1.1.1 brings a more stable home screen and improved English support.
+Version 1.1.3 makes recording chores faster and more reliable.
+
+New
+- Added Bulk Mode — pick multiple chores and record them in one go. Great for logging chores in batches after the kids are done.
+- When a chore is already recorded for the same day, the task card now shows an "Already recorded N time(s)" badge so it's easy to avoid double-logging.
 
 Bug fixes
-- Fixed an issue where your children's cards and stats sometimes failed to appear the first time the Home screen opened.
-- Fixed the "Version" row on the Settings screen so it now shows the current version (1.1.1) correctly instead of an outdated number.
+- Fixed an issue where the chore history and monthly history sheets could appear empty the first time they were opened.
 
 Improved English support
-- Tab labels (Home / Record / Settings), the Retrospective screen, each section of the Settings screen, notification settings, and the body text of reminder notifications now display naturally in English.
+- Added English translations for alert messages, the default help task names, and count phrases (one / other variants).
+- Fixed several truncated and untranslated labels in Settings and the child selection card so the UI reads more naturally in English.
 
-Thank you for using Otetsudai Coin — we hope you keep enjoying it together with your family!
+Thank you for using Otetsudai Coin — we hope you keep enjoying it with your family!


### PR DESCRIPTION
## 背景

#50（英語ストア掲載文の追加）の Phase 1 コンテンツは #119 で fastlane scaffold としてドラフト済みだが、`fastlane/metadata/en-US/release_notes.txt` が **v1.1.1 の What's New** のままだった。

英語ロケーションはまだ ASC へ未配信のため、これから en localization を追加すると **現行 live バージョン (v1.1.3) に v1.1.1 の What's New が付くバージョン不整合**になる（`RELEASE_v1.1.3.md`: 「v1.1.2 は ASC 公開に至らなかったため user 視点では v1.1.1 → v1.1.3」）。

## 変更内容

`RELEASE_v1.1.3.md § 2.5` の en draft（絵文字なし / Issue #85 対応済み）を `release_notes.txt` に反映。

## Spot-review（assistant 一次目視）

| 項目 | 判定 |
|---|---|
| 文字数 | ✅ 846 / 4000 字 |
| 絵文字 NG（en locale） | ✅ 非ASCIIは em-dash(—)のみ＝許容 |
| バージョン整合 | ✅ v1.1.1 言及 0 / v1.1.3 言及 1 |

## #50 残タスク（本 PR スコープ外・人間の ASC 操作待ち）

- [ ] ASC で English (U.S.) ロケーション追加（手動 / ユーザー）
- [ ] `fastlane deliver`（`upload_metadata` lane、認証付きで人間実行）または ASC UI 手入力
- [ ] 英語スクショ（`docs/screenshots/asc/v1.1.x/en/`）を ASC へアップロード
- [ ] ASC で英語ロケーション「保存」

> description / keywords / promotional_text / subtitle はバージョン非依存で配信 ready 済み。本 PR は唯一の version-dependent フィールド（What's New）を live バージョンに整合させるもの。

## Test plan

- [x] `wc -m` で 4000 字制限内を確認
- [x] 非ASCII scan で絵文字混入なし（em-dash のみ）を確認
- [x] v1.1.1 言及が全て v1.1.3 へ置換されたことを grep で確認

Refs #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)