### PR TITLE
fix(#125): 月のまとめの UX polish（スワイプ方向 + 空月¥0 CTA）

### DIFF
--- a/app/OtetsudaiCoin/Presentation/ViewModels/MonthlySummaryViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/MonthlySummaryViewModel.swift
@@ -69,6 +69,21 @@ class MonthlySummaryViewModel {
         selectedMonth = candidate
     }
 
+    /// 水平スワイプの translation 幅から月ナビを行う（View の DragGesture から呼ぶ）。
+    /// iOS 慣習: 左スワイプ（width < 0）= 次の月へ進む / 右スワイプ（width > 0）= 前の月へ戻る。
+    /// 月が移動したら true を返し、呼び出し側が loadMonth を kick する。
+    @discardableResult
+    func handleHorizontalSwipe(translationWidth: CGFloat) -> Bool {
+        if translationWidth < -50 {
+            goToNextMonth()
+            return true
+        } else if translationWidth > 50 {
+            goToPreviousMonth()
+            return true
+        }
+        return false
+    }
+
     // MARK: - Payment
 
     /// 表示中の月の「未払い残額」を支払う。完済済みなら no-op。
@@ -204,6 +219,9 @@ class MonthlySummaryViewModel {
         month: Int,
         expected: Int
     ) -> MonthSnapshot.PaymentStatus {
+        // M-2(#125): 獲得 0 の月は支払い対象なし → .paid 扱い（空月で ¥0 支払い CTA を出さない）。
+        if expected <= 0 { return .paid }
+
         let monthPayments = payments.filter { $0.year == year && $0.month == month }
         let totalPaid = monthPayments.reduce(0) { $0 + $1.amount }
 

--- a/app/OtetsudaiCoin/Presentation/Views/MonthlySummaryView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/MonthlySummaryView.swift
@@ -32,11 +32,7 @@ struct MonthlySummaryView: View {
         .gesture(
             DragGesture(minimumDistance: 50)
                 .onEnded { value in
-                    if value.translation.width < -50 {
-                        viewModel.goToPreviousMonth()
-                        Task { await viewModel.loadMonth() }
-                    } else if value.translation.width > 50 {
-                        viewModel.goToNextMonth()
+                    if viewModel.handleHorizontalSwipe(translationWidth: value.translation.width) {
                         Task { await viewModel.loadMonth() }
                     }
                 }

--- a/app/OtetsudaiCoinTests/Presentation/MonthlySummaryViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/MonthlySummaryViewModelTests.swift
@@ -259,4 +259,69 @@ final class MonthlySummaryViewModelTests: XCTestCase {
         XCTAssertEqual(comps.month, 1, "12月の次は1月")
         XCTAssertEqual(comps.year, currentYear, "前年12月 → 今年1月で年が繰り上がる (Dec→Jan)")
     }
+
+    // MARK: - #125 M-1: 水平スワイプの方向（iOS 慣習に合わせる）
+
+    // 起点を「前月」にし、左スワイプ→当月（== currentMonthStart で future-guard を通過）を期待。
+    // 当月/前月の相対起点に限定することで実行日・年境界に依存しない（#112/#114/#115 の date-math 弱点予防）。
+    @MainActor
+    func testSwipeLeftAdvancesToNextMonth() {
+        let cal = Calendar.current
+        let currentStart = cal.date(from: cal.dateComponents([.year, .month], from: Date()))!
+        let lastMonth = cal.date(byAdding: .month, value: -1, to: currentStart)!
+
+        let vm = MonthlySummaryViewModel(
+            child: child,
+            helpRecordRepository: mockHelpRecordRepository,
+            helpTaskRepository: mockHelpTaskRepository,
+            allowancePaymentRepository: mockAllowancePaymentRepository,
+            initialMonth: lastMonth
+        )
+
+        vm.handleHorizontalSwipe(translationWidth: -60)
+
+        let comps = cal.dateComponents([.year, .month], from: vm.selectedMonth)
+        let expected = cal.dateComponents([.year, .month], from: currentStart)
+        XCTAssertEqual(comps.year, expected.year, "左スワイプ（width<0）は次の月（当月）へ進むべき")
+        XCTAssertEqual(comps.month, expected.month, "左スワイプ（width<0）は次の月（当月）へ進むべき")
+    }
+
+    // 起点を「当月」にし、右スワイプ→前月を期待。buggy 方向だと goToNextMonth が future-guard で no-op になり当月のまま fail する。
+    @MainActor
+    func testSwipeRightGoesToPreviousMonth() {
+        let cal = Calendar.current
+        let currentStart = cal.date(from: cal.dateComponents([.year, .month], from: Date()))!
+
+        let vm = MonthlySummaryViewModel(
+            child: child,
+            helpRecordRepository: mockHelpRecordRepository,
+            helpTaskRepository: mockHelpTaskRepository,
+            allowancePaymentRepository: mockAllowancePaymentRepository,
+            initialMonth: currentStart
+        )
+
+        vm.handleHorizontalSwipe(translationWidth: 60)
+
+        let comps = cal.dateComponents([.year, .month], from: vm.selectedMonth)
+        let expected = cal.dateComponents([.year, .month], from: cal.date(byAdding: .month, value: -1, to: currentStart)!)
+        XCTAssertEqual(comps.year, expected.year, "右スワイプ（width>0）は前の月へ戻るべき")
+        XCTAssertEqual(comps.month, expected.month, "右スワイプ（width>0）は前の月へ戻るべき")
+    }
+
+    // MARK: - #125 M-2: 記録ゼロの月は ¥0 支払い CTA を出さない
+
+    @MainActor
+    func testEmptyMonthIsPaidSoNoCTA() async {
+        mockHelpTaskRepository.tasks = []
+        mockHelpRecordRepository.records = []
+        mockAllowancePaymentRepository.payments = []
+
+        await viewModel.loadMonth()
+
+        XCTAssertEqual(viewModel.snapshot?.totalCoins, 0, "前提: 記録ゼロで獲得コインは 0")
+        XCTAssertEqual(
+            viewModel.snapshot?.paymentStatus, .paid,
+            "獲得 0 の月は支払い対象なし → .paid（CTA 非表示）。空月で ¥0 CTA が出る回帰を防ぐ"
+        )
+    }
 }


### PR DESCRIPTION
## 概要

#125 の MonthlySummaryView UX polish 2件（#57 code review で検出されたスコープ外・既存 issue）を TDD で修正。Closes #125。

## M-1: スワイプ方向を iOS 慣習に合わせる

月切替の `DragGesture` が左スワイプ=前月 / 右スワイプ=次月 で、iOS 慣習（左=進む/次・右=戻る/前）と逆だった。

- direction mapping を `MonthlySummaryViewModel.handleHorizontalSwipe(translationWidth:)` に**抽出してテスト可能化**し、左スワイプ=`goToNextMonth` / 右スワイプ=`goToPreviousMonth` へ反転。
- 月ナビの `‹`(前) / `›`(次) ボタンとも整合。
- View の `DragGesture.onEnded` は `handleHorizontalSwipe` の戻り値（移動したか）で `loadMonth()` を kick（従来挙動を保持）。

## M-2: 記録ゼロの月で ¥0 支払い CTA を出さない

記録のない月は `totalCoins = 0` → `computePaymentStatus` が `.unpaid` を返し、「この月のお小遣いを支払う ¥0」CTA が表示（タップしても `remainder > 0` ガードで no-op）。

- `computePaymentStatus` の先頭に `expected <= 0 → .paid` ガードを追加（issue の対応案(b)）。
- **採用根拠（grep 確認）**: `MonthSnapshot.paymentStatus` の consumer は (1) `payCurrentMonth` のガード（`remainder > 0` で元々 no-op = 挙動不変）と (2) View の CTA gate のみ。「支払い済みバッジ」的な表示はなく、HomeView の未払い警告は `HomeViewModel` の別経路（`unpaidPeriods`/`showUnpaidWarning`）で `MonthSnapshot` 非依存のため、空月を `.paid` 扱いしても誤表示は起きない。

## テスト（RED→GREEN 確認済み）

`MonthlySummaryViewModelTests` に3件追加。3件とも RED（exit 65 / Failing tests に列挙）→ 修正後 GREEN（`** TEST SUCCEEDED **`）を確認。

- `testSwipeLeftAdvancesToNextMonth` — 左スワイプ→次月
- `testSwipeRightGoesToPreviousMonth` — 右スワイプ→前月
- `testEmptyMonthIsPaidSoNoCTA` — 獲得0の月は `.paid`

年境界フレーク対策（#112/#114/#115 の date-math 弱点予防）として、スワイプテストの起点は「当月/前月」相対に限定し future-guard / 12ヶ月フロアを確実に通過する構成にしている。

## 検証境界（意図的に unit-test 範囲外）

- **gesture plumbing**（`DragGesture` → `handleHorizontalSwipe` 配線）と **CTA gate**（`if snap.paymentStatus != .paid`）の1行は ViewInspector で gesture を simulate できず、simctl にも empty past month へ到達する tap 操作が無いため、unit-test 対象外。ロジック本体は上記3つの ViewModel テストで担保（advisor 確認済みの正しい境界）。
- ローカルは対象テストクラスのみ実行（blast radius が ViewModel/View 2ファイルに限定されるため）。フルスイートは CI に委譲。

## Plan からの逸脱

なし（user 承認の TDD 直接修正フロー）。M-1 を「コード読み+目視」で済ませる当初案は、advisor 指摘で `handleHorizontalSwipe` 抽出によるテスト可能化に変更（date-nav は本リポの反復弱点のため高価値ガード）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)