### PR TITLE
fix(#132): bulk記録テストの固定sleepをwaitUntil pollingに置換しflake解消

### DIFF
--- a/app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/RecordViewModelTests.swift
@@ -412,7 +412,7 @@ final class RecordViewModelTests: XCTestCase {
 
         // When
         viewModel.recordBulkHelp()
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        await waitUntil(timeout: 2.0) { !self.viewModel.isLoading }
 
         // Then: 2 件保存、失敗 1 件のみ selectedTaskIds に残る、合計コイン 40
         XCTAssertEqual(mockHelpRecordRepository.records.count, 2)
@@ -436,7 +436,7 @@ final class RecordViewModelTests: XCTestCase {
 
         // When
         viewModel.recordBulkHelp()
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        await waitUntil(timeout: 2.0) { !self.viewModel.isLoading }
 
         // Then: 0 件保存、選択は全て残る、error メッセージ
         XCTAssertEqual(mockHelpRecordRepository.records.count, 0)
@@ -459,7 +459,7 @@ final class RecordViewModelTests: XCTestCase {
 
         // When
         viewModel.recordBulkHelp()
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        await waitUntil(timeout: 2.0) { !self.viewModel.isLoading }
 
         // Then: success message に count=1 が反映され、ja sourceLanguage のため
         // "1 件記録しました！" (variations 未定義のため interpolation 経由でも他キーは使われる)
@@ -483,7 +483,7 @@ final class RecordViewModelTests: XCTestCase {
 
         // When
         viewModel.recordBulkHelp()
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        await waitUntil(timeout: 2.0) { !self.viewModel.isLoading }
 
         // Then
         XCTAssertNotNil(viewModel.warningMessage)
@@ -505,7 +505,7 @@ final class RecordViewModelTests: XCTestCase {
 
         // When
         viewModel.recordBulkHelp()
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        await waitUntil(timeout: 2.0) { !self.viewModel.isLoading }
 
         // Then: 3 件保存、selectedTaskIds 空、合計 60 コイン、success メッセージ
         XCTAssertEqual(mockHelpRecordRepository.records.count, 3)


### PR DESCRIPTION
## 概要

Issue #132。`test_recordBulkHelp_*` 系テストが `recordBulkHelp()` 内部の fire-and-forget `Task{}` の完了を **固定 `Task.sleep(200ms)`** で待っており、parallel/負荷時に bulk 書き込み完了を追い越して `XCTAssertEqual(records.count, ...)` などで flake していた。

issue は `test_recordBulkHelp_allSuccess` を名指しだが、**同一 root cause（固定 200ms 待ち）が同ファイルの bulk テスト 5 件に存在**したため、5 件まとめて決定的化した。

## 変更点

5 件の `try? await Task.sleep(nanoseconds: 200_000_000)` を、**同ファイルで確立済みの polling ヘルパー** `waitUntil(timeout:condition:)`（既存 10 箇所で使用、`RecordViewModelTests.swift:297`）に統一:

```swift
await waitUntil(timeout: 2.0) { !self.viewModel.isLoading }
```

`recordBulkHelp` の `Task{}` は終端で `setLoading(false)` を呼ぶ（`RecordViewModel.swift:259`）。`setLoading(true)` は `recordBulkHelp()` 内で同期的に先行実行されるため、`!isLoading` は「bulk 処理が全 state 確定まで完了した」決定的シグナルになる。assertion は一切変更せず、**待機だけを固定 → 適応 polling に置換**。

対象 5 テスト: `allSuccess` / `partialFailure_failedRemain` / `allFailed` / `singleSuccess_usesPluralOneVariation` / `partialFailure_setsWarningMessage`

## 検証

**RED/GREEN 実証**（mock `save` に 300ms 遅延を一時注入して再現 → 検証後 revert、コミットには含まない）:

| 条件 | 結果 |
| --- | --- |
| 旧 200ms 固定待ち + 300ms 遅延 | `allSuccess` **FAIL**（`records.count != 3`、exit 65） |
| 新 polling + 300ms 遅延 | 全 5 **PASS** |
| 新 polling・`-parallel-testing-enabled NO`・遅延なし | 全 5 **PASS**（0.086s、各 ~0.02s） |

旧 200ms 固定待ちが破綻する遅延条件で、新 polling は正しく待って pass することを実証。

## 既知の残課題（本 PR スコープ外・透明性のため記載）

フルクラスを **並列クローン実行**した際、`test_recordBulkHelp_allFailed` が 1 回だけ 7.15s で fail した。`waitUntil` は wall-clock 上限（`Date() < deadline`）のため 7.15s の原因ではなく、**2.0s deadline 到達 → `isLoading` が true のまま → `errorMessage` 未設定 → `XCTAssertNotNil(errorMessage)` fail** が機序。`allFailed` は遅起動テスト（GREEN 遅延実行でも最遅 4.575s）で、クローン/ホスト warmup + 当該プロセスの CPU 枯渇が 2.0s 窓を超えたもの。

- **isolated 再実行は PASS**（CLAUDE.md「iOS テスト flake 切り分け」の受理基準）。
- 本変更は**構造的に regression ではない**: 旧コードは固定 200ms 待ちで、新 2.0s 待ちでも足りなかった同じ窓では、旧 200ms はより確実に fail していた（200 < 2000）。
- これは本リポの**並列 simulator 過負荷 flake**（CLAUDE.md に既記載）に該当する一般課題で、本 PR が除去した「固定 200ms sleep 依存」とは別レイヤー。

## Plan からの逸脱

- issue は `allSuccess` 1 件を名指しだが、同一 flake クラスの bulk テスト **5 件**を一括修正（out-of-scope の別バグではなく #132 が指す flake クラスそのもの）。

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
