### PR TITLE
fix(ci): claude-review の404解消（retire済みデフォルトモデルを現行IDに固定）

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,9 +37,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
+          # Pin a current model. The action's implicit default (claude-sonnet-4-20250514)
+          # was retired 2026-06-15 and now returns "API Error: 404 not_found_error",
+          # which made this check fail on every PR. Use a current model ID instead;
+          # do NOT uncomment a dated Opus 4 ID — claude-opus-4-20250514 retired the same day.
+          model: "claude-sonnet-4-6"
+
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Please review this pull request and provide feedback on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,9 +40,12 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
+          # Pin a current model. The action's implicit default (claude-sonnet-4-20250514)
+          # was retired 2026-06-15 and now returns "API Error: 404 not_found_error".
+          # Use a current model ID; do NOT uncomment a dated Opus 4 ID —
+          # claude-opus-4-20250514 retired the same day.
+          model: "claude-sonnet-4-6"
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
           


### PR DESCRIPTION
## 概要

`claude-review` チェック（`.github/workflows/claude-code-review.yml`）が、全 PR で **`API Error: 404 not_found_error`** を返して失敗していた問題を修正します。

## 原因

`anthropics/claude-code-action@beta` は **モデル未指定時のデフォルトが `claude-sonnet-4-20250514`（Claude Sonnet 4）**。このモデルは **2026-06-15 に retire** され、以降 404 を返すようになりました。ワークフロー側でモデルを明示していなかったため、6/15 以降すべての PR で claude-review が落ちていました。

- 故障の境界が一致: claude-code-review.yml の実行履歴は **〜2026-06-10 まで全て `success`**、**6/21 から #134 / #131 の両方が `failure`**。
- ジョブログの決定打: `"text": "API Error: 404 {\"type\":\"error\",\"error\":{\"type\":\"not_found_error\",\"message\":\"model: claude-sonnet-4-20250514\"}...`
- PR のコードとは無関係な CI インフラ問題（全 PR 共通）。

## 修正

`claude-code-review.yml` と `claude.yml`（@claude メンション用）の両方で、`model` を現行 ID **`claude-sonnet-4-6`** に明示固定。

- これまでのデフォルト（Sonnet 4）と同じ Sonnet ティアを復元。PR ごとに走るレビュー bot 用途として高速・低コスト。
- ⚠️ ファイル内コメントが勧める `# model: "claude-opus-4-20250514"` の**コメントアウト解除は不採用**。この dated Opus 4 ID も **同じ 2026-06-15 に retire 済み**で、404 を 404 に置き換えるだけのため。
- `claude-sonnet-4-6` は Claude モデルカタログ上の現行・GA モデル。修正は **correct-by-construction**（後述の通り、この PR 自体では end-to-end の実測確認まではできない）。

## 検証結果（実測）

ローカルで両ファイルの YAML 妥当性を確認済み（`ruby -ryaml`）。

⚠️ **この PR 自体の `claude-review` チェックは red のままになります（ワークフロー改変 PR の仕様上、回避不可）。** ジョブログで以下を確認:

1. `model: claude-sonnet-4-6` が input として正しく渡った（`ALL_INPUTS` で確認 = YAML が正しくパースされた）。
2. ただし実行は **App token exchange 段階で 401 で停止**: `Workflow validation failed - The workflow file must exist and have identical content to the version on the repository's default branch`。これは Claude GitHub App のセキュリティゲートで、**PR がワークフローファイル自体を改変している**ため main 版と差分が生じて弾かれる。**モデル API 呼び出しの手前で止まる**ため、この PR の run では `claude-sonnet-4-6` の API 受理までは実測できていない（404 が出ないのは「API が受理した」証明ではなく「そこまで到達していない」だけ）。ログ自身も *"this is normal and you should ignore this error"* と明記。

→ **このゲートはワークフロー改変 PR では必ず発生し、merge してはじめて解消する。**

### end-to-end の確認手順（merge 後）
本 PR を merge 後、**ワークフローを触らない既存 PR（#134 等）の claude-review を re-run** する。その run の merge ref には更新後のワークフロー（=`claude-sonnet-4-6`）が含まれ、(a) Workflow-validation が通り（内容が main と一致）、(b) はじめて `claude-sonnet-4-6` の API 呼び出しが実行される。ここで緑になれば修正が end-to-end で実証される。

## マージ推奨

main は branch protection なし＝claude-review は必須チェックではないため、本 PR の red チェックは merge をブロックしません。red の正体は「ワークフロー改変 PR の自己検証ゲート」であり、修正内容とは別物です。仮にモデル文字列が誤っていても最悪 red のまま（=現状維持・退行なし）なので、**low-risk で現状より厳密に良い**。merge して問題ありません。

## スコープ / 別 PR にした理由

- これは **CI ワークフローのインフラ修正**であり、対象 issue（#132 等）のコードとは無関係。CLAUDE.md「別目的の PR に無関係なファイルを同梱しない」に従い、独立 PR として origin/main 起点で作成。
- なお既存の **PR #134 自体はマージ可能**（main は branch protection なし）。本 PR は全 PR 共通の赤チェックを恒久修正するもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)