### PR TITLE
fix(#136): sortByFrequency の並びを永続化 body 内で再計算 + 成功時に errorMessage をクリア

### DIFF
--- a/app/OtetsudaiCoin/Presentation/ViewModels/TaskManagementViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/TaskManagementViewModel.swift
@@ -150,6 +150,7 @@ class TaskManagementViewModel {
                 // DB の再採番 (0..n-1) を in-memory にもミラーし、後続の toggle/編集が
                 // stale な sortOrder を書き戻すのを防ぐ
                 tasks = reordered.enumerated().map { $1.updatingSortOrder($0) }
+                errorMessage = nil // 先行する失敗永続化が残した errorMessage をクリア (#136)
             } catch {
                 let message = ErrorMessageConverter.convertToUserFriendlyMessage(error)
                 await loadTasks() // DB の状態に巻き戻す
@@ -181,24 +182,26 @@ class TaskManagementViewModel {
             return
         }
 
-        // 全子ども合算で件数集計
+        // 全子ども合算で件数集計（records 由来で reorder 非依存なので body 外で確定してよい）
         let counts = Dictionary(grouping: records, by: { $0.helpTaskId }).mapValues { $0.count }
 
-        let sorted = tasks.sorted { lhs, rhs in
-            let lhsCount = counts[lhs.id] ?? 0
-            let rhsCount = counts[rhs.id] ?? 0
-            if lhsCount != rhsCount {
-                return lhsCount > rhsCount
-            }
-            return lhs.name < rhs.name
-        }
-
         await enqueueSortPersist { [self] in
+            // 並べ替え結果は永続化 body の実行時点の tasks から計算する。呼び出し時に capture すると、
+            // 先行する永続化の完了待ち中に tasks の集合が変わった場合に stale な並びを書きうる (#136)。
+            let sorted = tasks.sorted { lhs, rhs in
+                let lhsCount = counts[lhs.id] ?? 0
+                let rhsCount = counts[rhs.id] ?? 0
+                if lhsCount != rhsCount {
+                    return lhsCount > rhsCount
+                }
+                return lhs.name < rhs.name
+            }
             do {
                 try await helpTaskRepository.updateSortOrders(sorted.map(\.id))
                 // DB の再採番 (0..n-1) を in-memory にもミラー（moveTasks と同様）
                 tasks = sorted.enumerated().map { $1.updatingSortOrder($0) }
                 successMessage = String(localized: "よく使う順に並べ替えました")
+                errorMessage = nil // 先行する失敗永続化が残した errorMessage をクリア (#136)
             } catch {
                 let message = ErrorMessageConverter.convertToUserFriendlyMessage(error)
                 await loadTasks() // DB の状態に巻き戻す

--- a/app/OtetsudaiCoinTests/Presentation/ViewModels/TaskManagementViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/ViewModels/TaskManagementViewModelTests.swift
@@ -247,6 +247,51 @@ final class TaskManagementViewModelTests: XCTestCase {
         XCTAssertEqual(mockTaskRepository.updateSortOrdersCallCount, 2, "両方の永続化が実行されるべき")
     }
 
+    // MARK: - errorMessage 残留の解消 (#136)
+
+    func testSuccessfulSortClearsStaleErrorFromPriorFailedPersist() async {
+        // 失敗した永続化が errorMessage をセットしたまま、後続の成功永続化が走っても
+        // errorMessage が残るケースを潰す (#136 副次所見)。永続化は直列化されるため、
+        // 「敗北した失敗 persist の後に成功 persist が走る」並行ケースは、enqueue 順に並べた
+        // この逐次ケースに帰着する。最後に成功した永続化の結末が最終状態であるべき。
+        let taskA = makeTask(name: "A", sortOrder: 0)
+        let taskB = makeTask(name: "B", sortOrder: 1)
+        mockTaskRepository.tasks = [taskA, taskB]
+        await viewModel.loadTasks()
+
+        // 1) まず永続化を失敗させて errorMessage をセット
+        mockTaskRepository.shouldThrowErrorOnUpdateSortOrders = true
+        await viewModel.sortByFrequency(now: fixedNow)
+        XCTAssertNotNil(viewModel.errorMessage, "失敗永続化で errorMessage がセットされるべき")
+
+        // 2) 次の永続化を成功させると、前回の errorMessage はクリアされるべき
+        mockTaskRepository.shouldThrowErrorOnUpdateSortOrders = false
+        await viewModel.sortByFrequency(now: fixedNow)
+
+        XCTAssertNil(viewModel.errorMessage,
+                     "後続の成功永続化は古い errorMessage をクリアすべき（残: \(String(describing: viewModel.errorMessage))）")
+        XCTAssertNotNil(viewModel.successMessage, "成功永続化では successMessage がセットされるべき")
+    }
+
+    func testSuccessfulReorderClearsStaleErrorFromPriorFailedPersist() async {
+        // 上と同じ不変条件を reorder 経路 (persistReorder) でも担保する。
+        let taskA = makeTask(name: "A", sortOrder: 0)
+        let taskB = makeTask(name: "B", sortOrder: 1)
+        let taskC = makeTask(name: "C", sortOrder: 2)
+        mockTaskRepository.tasks = [taskA, taskB, taskC]
+        await viewModel.loadTasks()
+
+        mockTaskRepository.shouldThrowErrorOnUpdateSortOrders = true
+        await viewModel.moveTasks(from: IndexSet(integer: 2), to: 0)
+        XCTAssertNotNil(viewModel.errorMessage, "失敗した並べ替え永続化で errorMessage がセットされるべき")
+
+        mockTaskRepository.shouldThrowErrorOnUpdateSortOrders = false
+        await viewModel.moveTasks(from: IndexSet(integer: 2), to: 0)
+
+        XCTAssertNil(viewModel.errorMessage,
+                     "後続の成功した並べ替え永続化は古い errorMessage をクリアすべき（残: \(String(describing: viewModel.errorMessage))）")
+    }
+
     // MARK: - sortOrder 保持/採番
 
     func testAddTaskAppendsToEndWithMaxSortOrderPlusOne() async {


### PR DESCRIPTION
## 背景

`Closes #136`

#130（タスク並べ替え hardening）の最終 whole-branch レビューで **defer-to-follow-up** に分離された非ブロッキング concurrency 所見への対応です。本 PR では実際に何を直し、何を直していないかを以下に triage します。

## 何が出荷されたか / されていないか

| #136 の項目 | 種別 | 本 PR の対応 | テスト |
|---|---|---|---|
| (a) `sorted` を永続化 body 内へ移動 | 防御的リファクタ（挙動不変） | ✅ 実施 | 既存 sort/reorder テスト全件で regression ガード |
| (c) superseded 失敗 persist の errorMessage 残留 | **再現可能な実バグ** | ✅ 修正（成功時 `errorMessage = nil`） | RED→GREEN テスト 2 件追加 |
| 本文の「sort vs reorder で stale snapshot を書く」本命シナリオ | — | コード変更で footgun を除去（下記） | 再現する repro を構築できなかったため behavioral テストは追加せず |

## 変更内容

### (a) `sorted` を永続化 body 内で再計算
`TaskManagementViewModel.sortByFrequency` の `sorted` 計算を `enqueueSortPersist` の **body 外 → body 内**へ移動し、永続化 body の実行時点の最新 `tasks` から並びを計算するようにしました。`counts` は `records` 由来で reorder 非依存のため body 外のままです。

### (c) 成功時に errorMessage をクリア
`persistReorder` / `sortByFrequency` の成功 branch に `errorMessage = nil` を追加。永続化は直列化されているため「失敗 persist の後に成功 persist が走る」並行ケースは enqueue 順の逐次ケースに帰着し、**最後に成功した永続化が古いエラーを消す**のが正しい最終状態になります。

## 本命シナリオ（snapshot 上書き）についての所見

本文の「reorder の persist が先に enqueue → sort が reorder 前のスナップショット由来の `sorted` を書き込む」シナリオは、コードを追った範囲では **再現する repro を構築できませんでした**（#137 レビュアーの「非ブロッキング」判断と整合）。防御している主たるメカニズム：

- **reorder は `reorderTasks` で `tasks` を同期的に先更新してから永続化を enqueue** する。かつ `sortByFrequency` のスナップショット計算（`let sorted = ...`）と enqueue の間に **suspension point が無い**。
- このため、reorder が chain の先頭に居る（= sort より先に enqueue された）時点では `tasks` は必ず最新で、sort が「reorder 前の古い `tasks`」を掴む隙間が無い。

ただしこの不変条件は **構造に依存**します（同期先更新 + 中断点なし）。本 PR の (a) は、この 2 つの構造的不変条件が将来の refactor で静かに壊れても安全であるよう、**派生状態 `sorted` を直列化境界の内側で確定させる footgun 除去**として価値があります。「再現するバグの修正」ではなく「再現を防いでいる前提への依存を外す hardening」という位置づけです。

> 補足: 「頻度ソートは入力順非依存」も snapshot の安全性に寄与しますが、これは distinct な (件数, 名前) キーでのみ成立し、同名・同件数の tie では Swift の安定ソートにより入力順依存になります。主たる防御は上記の同期先更新 + 中断点なしです。

## スコープ境界

「成功した永続化が errorMessage をクリアする」不変条件は、本 PR で **sort / reorder 経路にのみ**成立します（`addTask` / `delete` / `toggleTaskStatus` / `updateTask` は対象外）。#136 のスコープに沿った境界で、必要なら別途追跡可能です。

## テスト

- `testSuccessfulSortClearsStaleErrorFromPriorFailedPersist`（sort 経路）
- `testSuccessfulReorderClearsStaleErrorFromPriorFailedPersist`（reorder 経路）

いずれも修正前は RED（成功後も errorMessage が残る）、修正後 GREEN。`OtetsudaiCoinTests` 全体 PASS（iPhone 17 / iOS 26.5）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)