### PR TITLE
fix(#152): RecordViewModel を @State 所有にしてタブ切替の状態リセットを解消

### DIFF
--- a/app/OtetsudaiCoin/ContentView.swift
+++ b/app/OtetsudaiCoin/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
     
     @State private var childManagementViewModel: ChildManagementViewModel
     @State private var homeViewModel: HomeViewModel
+    @State private var recordViewModel: RecordViewModel
     @State private var paymentReminderService: PaymentReminderNotificationService
 
     @MainActor
@@ -34,6 +35,9 @@ struct ContentView: View {
 
         _childManagementViewModel = State(wrappedValue: viewModelFactory.createChildManagementViewModel())
         _homeViewModel = State(wrappedValue: viewModelFactory.createHomeViewModel())
+        // body 再評価のたびに生成すると記録途中の選択状態が失われるため、
+        // 他の ViewModel と同様に @State で一度だけ生成する (Issue #152)
+        _recordViewModel = State(wrappedValue: viewModelFactory.createRecordViewModel())
 
         let paymentService = PaymentReminderNotificationService(
             notificationCenter: UNUserNotificationCenter.current(),
@@ -75,7 +79,7 @@ struct ContentView: View {
                 }
                 .tag(0)
             
-            RecordView(viewModel: viewModelFactory.createRecordViewModel())
+            RecordView(viewModel: recordViewModel)
                 .tabItem {
                     Image(systemName: "plus.circle.fill")
                     Text("記録")

--- a/app/OtetsudaiCoinUITests/OtetsudaiCoinUITests.swift
+++ b/app/OtetsudaiCoinUITests/OtetsudaiCoinUITests.swift
@@ -115,8 +115,44 @@ final class OtetsudaiCoinUITests: XCTestCase {
         let childSelectionText = app.staticTexts["お手伝いする人を選んでください"]
         XCTAssertTrue(childSelectionText.waitForExistence(timeout: 5), "子供選択エリアが表示されていません")
     }
-    
-    
+
+
+    // MARK: - Issue #152: タブ切替で記録画面の選択状態が保持されること
+
+    func testRecordTab_ChildSelectionPersistsAcrossTabSwitch() throws {
+        // 前提: loadChildren は未選択時に先頭の子を自動選択するため、
+        // 先頭の子では VM 再生成によるリセットが隠蔽される。
+        // 2 人目 (花子) を選択してタブ往復し、選択が先頭 (太郎) に戻らないことを検証する。
+
+        // 記録タブに移動
+        app.tabBars.buttons["記録"].tap()
+
+        // 2 人目の子供カード (花子) の表示を待ってタップ
+        // (Button は子 Text をラベルに統合するため label で判定)
+        let hanakoButton = app.buttons.matching(
+            NSPredicate(format: "identifier == 'child_button' AND label CONTAINS '花子'")
+        ).firstMatch
+        XCTAssertTrue(hanakoButton.waitForExistence(timeout: 5), "花子の子供カードが表示されていません")
+        hanakoButton.tap()
+
+        // 花子が選択状態になったことを確認
+        let selectedHanako = app.buttons.matching(
+            NSPredicate(format: "identifier == 'child_button' AND label CONTAINS '花子' AND label CONTAINS '選択中'")
+        ).firstMatch
+        XCTAssertTrue(selectedHanako.waitForExistence(timeout: 3), "花子が選択状態になっていません")
+
+        // ホームタブへ移動して記録タブへ戻る
+        app.tabBars.buttons["ホーム"].tap()
+        sleep(1)
+        app.tabBars.buttons["記録"].tap()
+
+        // 花子の選択が保持されていること（RecordViewModel が再生成されると先頭の子に戻る）
+        XCTAssertTrue(
+            selectedHanako.waitForExistence(timeout: 3),
+            "タブ切替後に花子の選択状態が失われました (Issue #152)"
+        )
+    }
+
     // MARK: - パフォーマンステスト
     
     func testPerformance_AppLaunch() throws {


### PR DESCRIPTION
## 概要

Closes #152

タブ切替のたびに記録画面の選択状態（選択中の子・タスク・一括モード等）がリセットされるバグを修正します。

## 原因

`ContentView.body` 内で `RecordView(viewModel: viewModelFactory.createRecordViewModel())` とインライン生成していたため、`selectedTab` 等の `@State` 変化で body が再評価されるたびに**新品の RecordViewModel に差し替わって**いました。`homeViewModel` / `childManagementViewModel` は init で `@State` として 1 回だけ生成されており、RecordViewModel だけパターンが異なっていました。

## 変更内容

- `recordViewModel` を `@State` プロパティ化し、init で 1 回だけ生成（他 VM と同一パターン）
- `RecordView(viewModel: recordViewModel)` に変更
- UI テスト `testRecordTab_ChildSelectionPersistsAcrossTabSwitch` を追加

## スコープ判断

- Tutorial 用の `createRecordViewModel()`（fullScreenCover 内）は**意図的に現状維持**: チュートリアルのデモ操作が本番タブの選択状態を汚さないよう、表示ごとの新規インスタンスが望ましいため

## テスト設計の注意点

`loadChildren` は未選択時に**先頭の子を自動選択**するため、先頭の子（太郎）で検証すると VM 再生成によるリセットが隠蔽されます（実際に最初の RED 試行が PASS してしまい発覚）。テストは **2 人目の花子を選択**してタブ往復し、「花子の選択が保持されること」を検証しています。

## 検証

- 🔴 RED: 修正前に `タブ切替後に花子の選択状態が失われました (Issue #152)` で fail することを xcresult で確認（exit=65）
- 🟢 GREEN: 修正後に同テスト PASS（94 秒）
- ✅ ユニットテスト 365 件 PASS（`-only-testing:OtetsudaiCoinTests`, exit=0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFxeFgZucQ3sLWC5tr3wjD

## セルフレビューで検出した既知のトレードオフ（コード変更なし）

1. **`recordedDate` の日跨ぎ**: VM 永続化により、アプリを起動したまま日付を跨ぐと記録日ピルが前日を指したままになる（修正前はタブ切替で偶発的に今日へ戻っていた）。自動リセットは「ユーザーが選んだ過去日付の保持」（本修正の目的）と衝突するため、意図的に対応しない。記録日は UI 上で常に視認可能
2. **UI テストの `child_button` identifier は HomeView にも存在**: 現状は Home 側カードに「選択中」表示が無く誤マッチしない（RED が正しいアサーションで fail することを xcresult で確認済み）。将来 Home 側に選択表示を足す場合はテストの predicate を見直すこと
