### PR TITLE
test(#153): MonthlyResetService / TutorialService の単体テスト追加

### DIFF
--- a/app/OtetsudaiCoin/Domain/Services/TutorialService.swift
+++ b/app/OtetsudaiCoin/Domain/Services/TutorialService.swift
@@ -7,22 +7,29 @@ class TutorialService {
     var hasCompletedRecordTutorial: Bool = false
     var showTutorial: Bool = false
     
-    private let userDefaults = UserDefaults.standard
-    
+    private let userDefaults: UserDefaults
+
     private enum Keys: String {
         case hasLaunchedBefore = "hasLaunchedBefore"
         case hasCompletedChildTutorial = "hasCompletedChildTutorial"
         case hasCompletedRecordTutorial = "hasCompletedRecordTutorial"
     }
-    
-    init() {
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
         loadTutorialState()
         checkFirstLaunch()
     }
-    
+
+    /// UIテスト起動時（`--uitesting` フラグ）かどうかを判定する pure helper。
+    /// 判定ロジックを注入可能にして unit test で担保する。
+    static func isUITesting(arguments: [String] = ProcessInfo.processInfo.arguments) -> Bool {
+        arguments.contains("--uitesting")
+    }
+
     func checkFirstLaunch() {
         // UIテスト実行時はチュートリアルをスキップ
-        if ProcessInfo.processInfo.arguments.contains("--uitesting") {
+        if Self.isUITesting() {
             hasCompletedChildTutorial = true
             hasCompletedRecordTutorial = true
             showTutorial = false

--- a/app/OtetsudaiCoin/Domain/Services/TutorialService.swift
+++ b/app/OtetsudaiCoin/Domain/Services/TutorialService.swift
@@ -27,9 +27,9 @@ class TutorialService {
         arguments.contains("--uitesting")
     }
 
-    func checkFirstLaunch() {
+    func checkFirstLaunch(isUITesting: Bool = TutorialService.isUITesting()) {
         // UIテスト実行時はチュートリアルをスキップ
-        if Self.isUITesting() {
+        if isUITesting {
             hasCompletedChildTutorial = true
             hasCompletedRecordTutorial = true
             showTutorial = false

--- a/app/OtetsudaiCoinTests/Domain/Services/MonthlyResetServiceTests.swift
+++ b/app/OtetsudaiCoinTests/Domain/Services/MonthlyResetServiceTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import OtetsudaiCoin
+
+/// `MonthlyResetService` の月・年境界の characterization テスト。
+///
+/// `checkAndPerformMonthlyReset()` は内部で `Date()` を直接読むため `now` は注入できない。
+/// そのため fixture は「実際の当月初 (currentMonthStart)」や「前年12月」に **アンカー** し、
+/// 実行日に依存しない決定的なテストにしている（CLAUDE.md の date-math flake 対策ルールに準拠）。
+final class MonthlyResetServiceTests: XCTestCase {
+
+    private var service: MonthlyResetService!
+    private var mockRepository: MockHelpRecordRepository!
+    private var userDefaults: UserDefaults!
+    private var calendar: Calendar!
+
+    private let suiteName = "MonthlyResetServiceTests"
+
+    override func setUp() {
+        super.setUp()
+        userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        mockRepository = MockHelpRecordRepository()
+        service = MonthlyResetService(helpRecordRepository: mockRepository, userDefaults: userDefaults)
+        calendar = Calendar.current
+    }
+
+    override func tearDown() {
+        userDefaults.removePersistentDomain(forName: suiteName)
+        service = nil
+        mockRepository = nil
+        userDefaults = nil
+        calendar = nil
+        super.tearDown()
+    }
+
+    // MARK: - getLastResetDate / setLastResetDate
+
+    func testGetLastResetDate_returnsNil_whenNeverSet() {
+        XCTAssertNil(service.getLastResetDate())
+    }
+
+    func testSetAndGetLastResetDate_roundTrips() {
+        let date = Date()
+        service.setLastResetDate(date)
+
+        let retrieved = service.getLastResetDate()
+        XCTAssertNotNil(retrieved)
+        // timeIntervalSince1970 を経由して永続化されるため、その精度で一致を確認する
+        XCTAssertEqual(retrieved!.timeIntervalSince1970, date.timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    // MARK: - checkAndPerformMonthlyReset: 記録日更新ロジック
+
+    func testCheckAndPerform_firstLaunch_recordsResetDate() async throws {
+        // 未設定（初回起動）の状態
+        XCTAssertNil(service.getLastResetDate())
+
+        try await service.checkAndPerformMonthlyReset()
+
+        let stored = service.getLastResetDate()
+        XCTAssertNotNil(stored, "初回起動ではリセット日が記録されるべき")
+        let currentMonthStart = calendar.dateInterval(of: .month, for: Date())!.start
+        // 記録された日付は今月内（当月初以降）であるべき
+        XCTAssertGreaterThanOrEqual(stored!, currentMonthStart)
+    }
+
+    func testCheckAndPerform_sameMonth_isNoOp() async throws {
+        // 当月初をリセット日として設定（now と同じ月）
+        let currentMonthStart = calendar.dateInterval(of: .month, for: Date())!.start
+        service.setLastResetDate(currentMonthStart)
+
+        try await service.checkAndPerformMonthlyReset()
+
+        // 同月なので更新されず、値は不変
+        let stored = service.getLastResetDate()
+        XCTAssertNotNil(stored)
+        XCTAssertEqual(stored!.timeIntervalSince1970, currentMonthStart.timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    func testCheckAndPerform_previousMonth_updatesResetDate() async throws {
+        // 前月にアンカーした fixture（実行日非依存）
+        let currentMonthStart = calendar.dateInterval(of: .month, for: Date())!.start
+        let previousMonth = calendar.date(byAdding: .month, value: -1, to: currentMonthStart)!
+        service.setLastResetDate(previousMonth)
+
+        try await service.checkAndPerformMonthlyReset()
+
+        // 新しい月なのでリセット日が前進しているべき（rollover-proof な「前進」比較）
+        let stored = service.getLastResetDate()
+        XCTAssertNotNil(stored)
+        XCTAssertGreaterThan(stored!, previousMonth)
+    }
+
+    func testCheckAndPerform_previousYearDecember_updatesResetDate() async throws {
+        // 前年12月にアンカー。月「番号」だけで比較する退行（12 > 現在月）を検知するガード。
+        let currentYear = calendar.component(.year, from: Date())
+        let previousYearDecember = calendar.date(
+            from: DateComponents(year: currentYear - 1, month: 12, day: 15)
+        )!
+        service.setLastResetDate(previousYearDecember)
+
+        try await service.checkAndPerformMonthlyReset()
+
+        // 前年12月は必ず当月より前 → 更新されて前進しているべき
+        let stored = service.getLastResetDate()
+        XCTAssertNotNil(stored)
+        XCTAssertGreaterThan(stored!, previousYearDecember)
+    }
+
+    // MARK: - リセットは削除しない（履歴保持）という契約
+
+    func testCheckAndPerform_staleMonth_doesNotDeleteRecords() async throws {
+        // 記録を2件シードしておく
+        let childId = UUID()
+        let taskId = UUID()
+        mockRepository.records = [
+            HelpRecord(id: UUID(), childId: childId, helpTaskId: taskId, recordedAt: Date()),
+            HelpRecord(id: UUID(), childId: childId, helpTaskId: taskId, recordedAt: Date())
+        ]
+
+        // 前月リセット（= 月次リセットが発火する条件）
+        let currentMonthStart = calendar.dateInterval(of: .month, for: Date())!.start
+        let previousMonth = calendar.date(byAdding: .month, value: -1, to: currentMonthStart)!
+        service.setLastResetDate(previousMonth)
+
+        try await service.checkAndPerformMonthlyReset()
+
+        // 「リセット」はデータ削除ではなく履歴保持。記録は1件も消えていないべき。
+        XCTAssertEqual(mockRepository.records.count, 2, "月次リセットは履歴を削除してはならない")
+    }
+}

--- a/app/OtetsudaiCoinTests/Domain/Services/MonthlyResetServiceTests.swift
+++ b/app/OtetsudaiCoinTests/Domain/Services/MonthlyResetServiceTests.swift
@@ -55,11 +55,15 @@ final class MonthlyResetServiceTests: XCTestCase {
         // 未設定（初回起動）の状態
         XCTAssertNil(service.getLastResetDate())
 
+        // await をまたぐ月末 straddle を避けるため now を await 前に確定しておく。
+        // production の Date() は必ずこの now 以降なので stored >= currentMonthStart が成り立つ。
+        let now = Date()
+        let currentMonthStart = calendar.dateInterval(of: .month, for: now)!.start
+
         try await service.checkAndPerformMonthlyReset()
 
         let stored = service.getLastResetDate()
         XCTAssertNotNil(stored, "初回起動ではリセット日が記録されるべき")
-        let currentMonthStart = calendar.dateInterval(of: .month, for: Date())!.start
         // 記録された日付は今月内（当月初以降）であるべき
         XCTAssertGreaterThanOrEqual(stored!, currentMonthStart)
     }
@@ -78,22 +82,27 @@ final class MonthlyResetServiceTests: XCTestCase {
     }
 
     func testCheckAndPerform_previousMonth_updatesResetDate() async throws {
-        // 前月にアンカーした fixture（実行日非依存）
-        let currentMonthStart = calendar.dateInterval(of: .month, for: Date())!.start
+        // now を await 前に確定し、前月にアンカーした fixture（実行日非依存 + rollover-proof）
+        let now = Date()
+        let currentMonthStart = calendar.dateInterval(of: .month, for: now)!.start
         let previousMonth = calendar.date(byAdding: .month, value: -1, to: currentMonthStart)!
         service.setLastResetDate(previousMonth)
 
         try await service.checkAndPerformMonthlyReset()
 
-        // 新しい月なのでリセット日が前進しているべき（rollover-proof な「前進」比較）
         let stored = service.getLastResetDate()
         XCTAssertNotNil(stored)
+        // 新しい月なのでリセット日が前進しているべき（rollover-proof な「前進」比較）
         XCTAssertGreaterThan(stored!, previousMonth)
+        // 前月の別日ではなく、当月初以降へ更新されたことを pin する
+        XCTAssertGreaterThanOrEqual(stored!, currentMonthStart)
     }
 
     func testCheckAndPerform_previousYearDecember_updatesResetDate() async throws {
         // 前年12月にアンカー。月「番号」だけで比較する退行（12 > 現在月）を検知するガード。
-        let currentYear = calendar.component(.year, from: Date())
+        let now = Date()
+        let currentMonthStart = calendar.dateInterval(of: .month, for: now)!.start
+        let currentYear = calendar.component(.year, from: now)
         let previousYearDecember = calendar.date(
             from: DateComponents(year: currentYear - 1, month: 12, day: 15)
         )!
@@ -101,10 +110,11 @@ final class MonthlyResetServiceTests: XCTestCase {
 
         try await service.checkAndPerformMonthlyReset()
 
-        // 前年12月は必ず当月より前 → 更新されて前進しているべき
         let stored = service.getLastResetDate()
         XCTAssertNotNil(stored)
+        // 前年12月は必ず当月より前 → 更新されて前進しているべき
         XCTAssertGreaterThan(stored!, previousYearDecember)
+        XCTAssertGreaterThanOrEqual(stored!, currentMonthStart)
     }
 
     // MARK: - リセットは削除しない（履歴保持）という契約
@@ -125,6 +135,8 @@ final class MonthlyResetServiceTests: XCTestCase {
 
         try await service.checkAndPerformMonthlyReset()
 
+        // まずリセットが実際に発火したことを確認（fixture 前提が崩れて no-op 化していないこと）
+        XCTAssertGreaterThan(service.getLastResetDate()!, previousMonth, "月次リセットが発火しているべき")
         // 「リセット」はデータ削除ではなく履歴保持。記録は1件も消えていないべき。
         XCTAssertEqual(mockRepository.records.count, 2, "月次リセットは履歴を削除してはならない")
     }

--- a/app/OtetsudaiCoinTests/Domain/Services/TutorialServiceTests.swift
+++ b/app/OtetsudaiCoinTests/Domain/Services/TutorialServiceTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import OtetsudaiCoin
+
+/// `TutorialService` の基本テスト（初回起動判定 / 完了状態の永続化 / `--uitesting` skip 判定）。
+///
+/// `UserDefaults` を注入して隔離した suite でテストする（`.standard` を汚さないため）。
+final class TutorialServiceTests: XCTestCase {
+
+    private var userDefaults: UserDefaults!
+    private let suiteName = "TutorialServiceTests"
+
+    private let hasLaunchedBeforeKey = "hasLaunchedBefore"
+    private let hasCompletedChildKey = "hasCompletedChildTutorial"
+    private let hasCompletedRecordKey = "hasCompletedRecordTutorial"
+
+    override func setUp() {
+        super.setUp()
+        userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        userDefaults.removePersistentDomain(forName: suiteName)
+        userDefaults = nil
+        super.tearDown()
+    }
+
+    // MARK: - --uitesting skip 判定（pure static helper）
+
+    func testIsUITesting_trueWhenFlagPresent() {
+        XCTAssertTrue(TutorialService.isUITesting(arguments: ["someApp", "--uitesting"]))
+    }
+
+    func testIsUITesting_falseWhenFlagAbsent() {
+        XCTAssertFalse(TutorialService.isUITesting(arguments: ["someApp", "-other"]))
+        XCTAssertFalse(TutorialService.isUITesting(arguments: []))
+    }
+
+    // MARK: - 初回起動判定
+
+    func testFirstLaunch_freshDefaults_showsTutorialAndMarksLaunched() {
+        let service = TutorialService(userDefaults: userDefaults)
+
+        XCTAssertTrue(service.isFirstLaunch, "初回起動と判定されるべき")
+        XCTAssertTrue(service.showTutorial, "初回起動ではチュートリアルを表示すべき")
+        XCTAssertTrue(
+            userDefaults.bool(forKey: hasLaunchedBeforeKey),
+            "初回起動後は hasLaunchedBefore が記録されるべき"
+        )
+    }
+
+    func testReturningUser_withChildTutorialCompleted_doesNotShowTutorial() {
+        // 既存ユーザー（起動済み）かつ子供チュートリアル完了済み
+        userDefaults.set(true, forKey: hasLaunchedBeforeKey)
+        userDefaults.set(true, forKey: hasCompletedChildKey)
+
+        let service = TutorialService(userDefaults: userDefaults)
+
+        XCTAssertFalse(service.isFirstLaunch)
+        XCTAssertFalse(service.showTutorial, "子供チュートリアル完了済みならチュートリアルは非表示")
+    }
+
+    func testReturningUser_withoutChildTutorial_showsTutorial() {
+        // 既存ユーザーだが子供チュートリアル未完了 → 表示すべき
+        userDefaults.set(true, forKey: hasLaunchedBeforeKey)
+
+        let service = TutorialService(userDefaults: userDefaults)
+
+        XCTAssertFalse(service.isFirstLaunch)
+        XCTAssertTrue(service.showTutorial, "子供未登録の既存ユーザーはチュートリアルを表示")
+    }
+
+    // MARK: - 完了状態の永続化
+
+    func testMarkChildTutorialCompleted_persistsAcrossInstances() {
+        let service = TutorialService(userDefaults: userDefaults)
+        service.markChildTutorialCompleted()
+
+        XCTAssertTrue(service.hasCompletedChildTutorial)
+
+        // 別インスタンスでも永続化された状態が読み込まれる
+        let reloaded = TutorialService(userDefaults: userDefaults)
+        XCTAssertTrue(reloaded.hasCompletedChildTutorial)
+    }
+
+    // MARK: - 表示ゲートの computed property
+
+    func testGatingProperties_reflectState() {
+        let service = TutorialService(userDefaults: userDefaults)
+
+        // 子供チュートリアル段階
+        service.showTutorial = true
+        service.hasCompletedChildTutorial = false
+        service.hasCompletedRecordTutorial = false
+        XCTAssertTrue(service.shouldShowChildTutorial)
+        XCTAssertFalse(service.shouldShowRecordTutorial)
+
+        // 記録チュートリアル段階（子供完了・記録未完了）
+        service.hasCompletedChildTutorial = true
+        XCTAssertFalse(service.shouldShowChildTutorial)
+        XCTAssertTrue(service.shouldShowRecordTutorial)
+
+        // 両方完了
+        service.hasCompletedRecordTutorial = true
+        XCTAssertFalse(service.shouldShowChildTutorial)
+        XCTAssertFalse(service.shouldShowRecordTutorial)
+    }
+
+    // MARK: - リセット
+
+    func testResetTutorial_clearsPersistedState() {
+        let service = TutorialService(userDefaults: userDefaults)
+        service.completeTutorial()  // 子供・記録の両方を完了状態にする
+
+        service.resetTutorial()
+
+        XCTAssertTrue(service.isFirstLaunch)
+        XCTAssertFalse(service.hasCompletedChildTutorial)
+        XCTAssertFalse(service.hasCompletedRecordTutorial)
+        XCTAssertTrue(service.showTutorial)
+        XCTAssertFalse(userDefaults.bool(forKey: hasLaunchedBeforeKey), "hasLaunchedBefore は消去されるべき")
+        XCTAssertFalse(userDefaults.bool(forKey: hasCompletedChildKey))
+        XCTAssertFalse(userDefaults.bool(forKey: hasCompletedRecordKey))
+    }
+}

--- a/app/OtetsudaiCoinTests/Domain/Services/TutorialServiceTests.swift
+++ b/app/OtetsudaiCoinTests/Domain/Services/TutorialServiceTests.swift
@@ -36,6 +36,17 @@ final class TutorialServiceTests: XCTestCase {
         XCTAssertFalse(TutorialService.isUITesting(arguments: []))
     }
 
+    func testCheckFirstLaunch_whenUITesting_skipsTutorial() {
+        // 初回起動状態から --uitesting 相当で再判定 → スキップ分岐（完了扱い・非表示）の効果を検証
+        let service = TutorialService(userDefaults: userDefaults)
+
+        service.checkFirstLaunch(isUITesting: true)
+
+        XCTAssertTrue(service.hasCompletedChildTutorial, "--uitesting では子供チュートリアルは完了扱い")
+        XCTAssertTrue(service.hasCompletedRecordTutorial, "--uitesting では記録チュートリアルは完了扱い")
+        XCTAssertFalse(service.showTutorial, "--uitesting ではチュートリアルを表示しない")
+    }
+
     // MARK: - 初回起動判定
 
     func testFirstLaunch_freshDefaults_showsTutorialAndMarksLaunched() {


### PR DESCRIPTION
## 概要

コード品質監査 (2026-07-06) で発見された「月次リセットの本丸 `MonthlyResetService` が無テスト」を解消し (#153)、`TutorialService` の基本テストも追加する。date math はこのリポの反復弱点 (#112 / #114 / #115) のため、CLAUDE.md の「相対日付でなく固定安全日にピン留め」「年境界は前年12月起点」ルールを厳守した。

## 変更内容

### MonthlyResetService（本丸・本体変更なし）

`checkAndPerformMonthlyReset()` は内部で `Date()` を直接読むため `now` は注入できない。fixture を「実際の当月初」「前年12月」に**アンカー**し、実行日非依存の characterization テストを追加した:

- `getLastResetDate` の nil / round-trip
- 初回起動 → リセット日を記録
- 同月 → no-op（値が不変）
- 前月 → 更新（rollover-proof な「前進」比較 + 当月初以降への更新を pin）
- 前年12月 → 更新（月「番号」だけで比較する退行を検知するガード）
- **リセット ≠ 削除**: stale-month リセット後に履歴（記録）が1件も消えないことを assert（リセット発火確認込み）

### TutorialService（issue で「優先度低・ついで」指定）

- `init(userDefaults: UserDefaults = .standard)` で UserDefaults を注入可能にし、`.standard` 汚染を回避。既存 5 箇所の `TutorialService()` 呼び出しは default 引数で後方互換。
- `--uitesting` skip 判定を pure static helper `isUITesting(arguments:)` に抽出（PR #115 の testable-static パターンに準拠）。
- `checkFirstLaunch(isUITesting:)` で skip 分岐の**効果本体**もテスト可能に。
- カバー範囲: `--uitesting` 判定 / skip 効果 / 初回起動判定 / 既存ユーザー / 完了状態の永続化 / 表示ゲート computed property / reset。

## テスト

- `MonthlyResetServiceTests` 7 件 + `TutorialServiceTests` 9 件を追加
- `OtetsudaiCoinTests` 全 381 ケース green（iPhone 17 Pro simulator）
- date-math テストは月初・年跨ぎ・月末 rollover いずれでも決定的（`now` を `await` 前に確定）

## 二段レビュー findings 対応

実装後に独立した 2 エージェントで code-quality レビューを実施し、以下を 2 commit 目で反映:

1. `staleMonth` テストがリセット発火を検証しておらず vacuous 気味だった → 発火 assert を追加
2. `--uitesting` skip の効果本体が未実行だった（#153 が明示要求）→ 直接テストを追加
3. update テストの月末 straddle 理論 flake / 現月 pin 不足 → `now` を `await` 前に確定 + assertion 強化

不対応（理由明記）:

- init 経路の実 `ProcessInfo` 依存: 既存 codebase も同依存で実 flake なし（unit-test scheme は `--uitesting` を注入しない）
- `sameMonth` の intrinsic straddle: clock 注入なしでは修正不能・発生確率 ~10⁻⁹

## Plan からの逸脱

- **TutorialService の DI + static helper 抽出**は「テスト追加」を超える production 変更だが、テスト隔離（`.standard` 汚染回避）と `--uitesting` 判定のテスト化に必須のため実施（既存 `MonthlyResetService` の DI パターン / PR #115 の static helper パターンに準拠）。
- 上記 production 変更を要するテストの RED は「未定義シンボル参照＝コンパイルエラー確定」（CLAUDE.md TDD skip 条件 a）のため個別 RED build を skip。`MonthlyResetService` は本体変更不要のため直接 green を確認し、相補的な same-month=不変 / previous-month=前進 の対で vacuous pass を排除した。

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pSrzi7gWRruq78WNHVMza
