### PR TITLE
docs(#141): GitHub Pages の公開範囲から screenshots を除外し公開ポリシーを明文化

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,10 @@
 title: おてつだいコイン
 description: 子供のお手伝いを楽しく記録して、お小遣い管理ができる iOS アプリ
+# 公開ポリシー: Pages で公開するのは index.html / privacy-policy.html / app-ads.txt のみ。
+# 開発文書（superpowers: plans/specs, releases）と ASC スクショ（screenshots）は exclude で非公開にする。
+# docs/ 配下に新しいディレクトリを追加するときは、ここへの exclude 追加を検討すること。
+# 注意: docs/.nojekyll を将来追加すると Jekyll が無効化され、この exclude 設定ごと効かなくなる。
 exclude:
   - superpowers
   - releases
+  - screenshots


### PR DESCRIPTION
## 背景
Issue #141 が指摘していた「`docs/` は GitHub Pages 公開ソースだが開発文書も同居している」問題のうち、[前コメント](https://github.com/es0612/OtetsudaiCoin/issues/141#issuecomment-4887992336) で判明した通り `superpowers`（plans/specs 30本）は既に `docs/_config.yml` の exclude で非公開化済みでした。残る論点は `docs/screenshots/`（ASC スクショ 6 枚, 1.4MB）だけが exclude 対象外で、Pages の公開 URL（`https://es0612.github.io/OtetsudaiCoin/screenshots/...`）から直接到達可能だった点です。

## 検討した選択肢と選定理由

**(a) `docs/_config.yml` の exclude に `screenshots` を追加**（採用）
- 既存の `exclude: [superpowers, releases]` と同形式で 1 行追加するだけの最小変更。
- 公開 2 ページ（`index.html` / `privacy-policy.html`）はいずれも開発文書・スクショに一切リンクしておらず、公開範囲を絞っても表示上の影響はない。
- `docs/.nojekyll` が存在しない（Jekyll 有効）ことを確認済みなので、exclude は引き続き機能する。

**(b) 開発文書ディレクトリを `docs/` 外へ物理移動**（見送り）
- `scripts/capture-asc-screenshots.sh:18` の `OUT_DIR="docs/screenshots/asc/v1.1.x"` ハードコードや、CLAUDE.md / `fastlane/SETUP.md` / `docs/releases/*.md` 内の多数のパス参照を同時に更新する必要があり、変更範囲・リスクに対して得られる効果が見合わない。
- ASC スクショは機密情報ではなく、公開されても実害は小さい。

## 変更内容
- `docs/_config.yml` の `exclude` に `screenshots` を追加。
- exclude リストの直前に公開ポリシーのコメントを追記（公開対象は `index.html` / `privacy-policy.html` / `app-ads.txt` のみ、新規ディレクトリ追加時は exclude 追加を検討、`docs/.nojekyll` を将来追加すると Jekyll が無効化され exclude ごと効かなくなる旨）。

## 検証
- `ruby -ryaml -e 'YAML.load_file("docs/_config.yml")'` で YAML 構文チェック OK。
- `docs/.nojekyll` が存在しないことを確認（Jekyll 有効 = exclude が機能する前提が成立）。
- Jekyll ローカルビルドは未実施（既存 2 エントリと同形式のためリスク極小と判断、タスク指示で明示的に waived）。
- 最終確認は merge 後の Pages 再デプロイで `https://es0612.github.io/OtetsudaiCoin/screenshots/asc/v1.1.x/ja/01-home.png` が 404 になることで裏取り可能。

## スコープ外
- `docs/` 配下のファイル移動・削除は行っていません。
- `scripts/capture-asc-screenshots.sh` は変更していません。

Closes #141
