### PR TITLE
fix(#144): エラーの print 握りつぶしを DebugLogger / ユーザー通知へ統一

### DIFF
--- a/app/OtetsudaiCoin/ContentView.swift
+++ b/app/OtetsudaiCoin/ContentView.swift
@@ -170,10 +170,10 @@ struct ContentView: View {
                 do {
                     try await paymentReminderService.reschedule()
                 } catch {
-                    print("支払いリマインド reschedule エラー: \(error)")
+                    DebugLogger.error("支払いリマインド reschedule エラー: \(error)")
                 }
             } catch {
-                print("初期データセットアップエラー: \(error)")
+                DebugLogger.error("初期データセットアップエラー: \(error)")
             }
         }
     }

--- a/app/OtetsudaiCoin/Domain/Services/SampleDataService.swift
+++ b/app/OtetsudaiCoin/Domain/Services/SampleDataService.swift
@@ -86,10 +86,7 @@ class SampleDataService {
             try await helpRecordRepository.save(record)
         }
         
-        print("📊 サンプルデータを生成しました:")
-        print("  - 子供: \(children.count)人")
-        print("  - タスク: \(helpTasks.count)個")
-        print("  - 記録: \(records.count)件（過去3ヶ月分）")
+        DebugLogger.debug("📊 サンプルデータを生成しました: 子供 \(children.count)人 / タスク \(helpTasks.count)個 / 記録 \(records.count)件（過去3ヶ月分）")
     }
     
     /// 全てのサンプルデータを削除
@@ -112,7 +109,7 @@ class SampleDataService {
             try await childRepository.delete(child.id)
         }
         
-        print("🗑️ 全てのデータを削除しました")
+        DebugLogger.debug("🗑️ 全てのデータを削除しました")
     }
     
     /// 記録のみを削除（子供とタスクは保持）
@@ -122,7 +119,7 @@ class SampleDataService {
             try await helpRecordRepository.delete(record.id)
         }
 
-        print("🗑️ 記録データのみ削除しました（\(allRecords.count)件）")
+        DebugLogger.debug("🗑️ 記録データのみ削除しました（\(allRecords.count)件）")
     }
 
     /// サンプルタスク定義。sortOrder を 0 始まりの連番で付与し、

--- a/app/OtetsudaiCoin/Domain/Services/SoundService.swift
+++ b/app/OtetsudaiCoin/Domain/Services/SoundService.swift
@@ -71,7 +71,7 @@ class SoundService: SoundServiceProtocol {
             try AVAudioSession.sharedInstance().setCategory(.ambient, mode: .default)
             try AVAudioSession.sharedInstance().setActive(true)
         } catch {
-            print("Failed to setup audio session: \(error)")
+            DebugLogger.error("Failed to setup audio session: \(error)")
         }
     }
     
@@ -80,7 +80,7 @@ class SoundService: SoundServiceProtocol {
             do {
                 try loadSound(soundType)
             } catch {
-                print("Failed to preload sound \(soundType): \(error)")
+                DebugLogger.error("Failed to preload sound \(soundType): \(error)")
             }
         }
     }

--- a/app/OtetsudaiCoin/Persistence.swift
+++ b/app/OtetsudaiCoin/Persistence.swift
@@ -103,10 +103,8 @@ struct PersistenceController {
                 // loadPersistentStores の return 前に同期実行される（PersistenceControllerTests で実証）。
                 Self.logger.error("Core Dataストアの読み込みに失敗しました: \(error.localizedDescription)")
                 loadError = error
-                #if DEBUG
                 let nsError = error as NSError
-                print("Core Data エラー詳細: \(nsError), \(nsError.userInfo)")
-                #endif
+                DebugLogger.error("Core Data エラー詳細: \(nsError), \(nsError.userInfo)")
             }
         }
 

--- a/app/OtetsudaiCoin/Presentation/ViewModels/NotificationSettingsViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/NotificationSettingsViewModel.swift
@@ -15,7 +15,11 @@ class NotificationSettingsViewModel {
         self.reminderTime = Self.dateFrom(hour: service.reminderHour, minute: service.reminderMinute)
     }
 
-    var scheduleError: Error?
+    /// スケジュール失敗時のユーザー向けメッセージ（Issue #144）。
+    /// 従来は `Error` をそのまま保持していたが、どの View からも読まれておらず
+    /// 通知失敗がユーザーに一切伝わらない silent failure になっていた。
+    /// `ErrorMessageConverter` で変換済みの文言を保持し、View 側で `.commonAlerts` から表示する。
+    var errorMessage: String?
 
     func toggleNotification(enabled: Bool) async {
         if enabled {
@@ -25,9 +29,9 @@ class NotificationSettingsViewModel {
                 isEnabled = true
                 do {
                     try await service.scheduleDaily()
-                    scheduleError = nil
+                    errorMessage = nil
                 } catch {
-                    scheduleError = error
+                    errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
                     service.isEnabled = false
                     isEnabled = false
                     service.cancelAll()
@@ -55,11 +59,16 @@ class NotificationSettingsViewModel {
         if service.isEnabled {
             do {
                 try await service.reschedule()
-                scheduleError = nil
+                errorMessage = nil
             } catch {
-                scheduleError = error
+                errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
             }
         }
+    }
+
+    /// View の alert dismiss から呼ばれる想定。
+    func clearErrorMessage() {
+        errorMessage = nil
     }
 
     private static func dateFrom(hour: Int, minute: Int) -> Date {

--- a/app/OtetsudaiCoin/Presentation/ViewModels/PaymentReminderNotificationSettingsViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/PaymentReminderNotificationSettingsViewModel.swift
@@ -6,7 +6,12 @@ class PaymentReminderNotificationSettingsViewModel {
 
     var isEnabled: Bool
     var reminderTime: Date
-    var scheduleError: Error?
+
+    /// スケジュール失敗時のユーザー向けメッセージ（Issue #144）。
+    /// 従来は `Error` をそのまま保持していたが、どの View からも読まれておらず
+    /// 支払いリマインドの失敗がユーザーに一切伝わらない silent failure になっていた。
+    /// `ErrorMessageConverter` で変換済みの文言を保持し、View 側で `.commonAlerts` から表示する。
+    var errorMessage: String?
 
     private let service: PaymentReminderNotificationServiceProtocol
 
@@ -24,9 +29,9 @@ class PaymentReminderNotificationSettingsViewModel {
                 isEnabled = true
                 do {
                     try await service.reschedule()
-                    scheduleError = nil
+                    errorMessage = nil
                 } catch {
-                    scheduleError = error
+                    errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
                     service.isEnabled = false
                     isEnabled = false
                     service.cancelAll()
@@ -54,11 +59,16 @@ class PaymentReminderNotificationSettingsViewModel {
         if service.isEnabled {
             do {
                 try await service.reschedule()
-                scheduleError = nil
+                errorMessage = nil
             } catch {
-                scheduleError = error
+                errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
             }
         }
+    }
+
+    /// View の alert dismiss から呼ばれる想定。
+    func clearErrorMessage() {
+        errorMessage = nil
     }
 
     private static func dateFrom(hour: Int, minute: Int) -> Date {

--- a/app/OtetsudaiCoin/Presentation/Views/NotificationSettingsView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/NotificationSettingsView.swift
@@ -51,5 +51,15 @@ struct NotificationSettingsView: View {
             }
         }
         .navigationTitle("通知設定")
+        .commonAlerts(
+            errorMessage: viewModel.errorMessage,
+            successMessage: nil,
+            onErrorDismiss: { viewModel.clearErrorMessage() }
+        )
+        .commonAlerts(
+            errorMessage: paymentViewModel.errorMessage,
+            successMessage: nil,
+            onErrorDismiss: { paymentViewModel.clearErrorMessage() }
+        )
     }
 }

--- a/app/OtetsudaiCoin/Presentation/Views/SplashScreenView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/SplashScreenView.swift
@@ -159,6 +159,6 @@ struct SplashScreenView: View {
 
 #Preview {
     SplashScreenView {
-        print("Splash completed")
+        DebugLogger.debug("Splash completed")
     }
 }

--- a/app/OtetsudaiCoinTests/Presentation/ViewModels/NotificationSettingsViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/ViewModels/NotificationSettingsViewModelTests.swift
@@ -115,7 +115,8 @@ final class NotificationSettingsViewModelTests: XCTestCase {
     func testToggleOnWithScheduleErrorRevertsState() async {
         // Given: 権限は許可されるがスケジュールが失敗する
         mockService.authorizationResult = true
-        mockService.scheduleDailyError = NSError(domain: "test", code: 1)
+        let underlyingError = NSError(domain: "test", code: 1)
+        mockService.scheduleDailyError = underlyingError
 
         // When: 通知を有効にしようとする
         await viewModel.toggleNotification(enabled: true)
@@ -123,7 +124,44 @@ final class NotificationSettingsViewModelTests: XCTestCase {
         // Then: エラーにより無効状態に戻る
         XCTAssertFalse(viewModel.isEnabled)
         XCTAssertFalse(mockService.isEnabled)
-        XCTAssertNotNil(viewModel.scheduleError)
+        // Issue #144: scheduleError (Error) はどの View からも読まれておらず、
+        // スケジュール失敗がユーザーに一切伝わらない silent failure だった。
+        // ユーザー向け文言 (ErrorMessageConverter 変換済み) を errorMessage に保持する。
+        XCTAssertEqual(
+            viewModel.errorMessage,
+            ErrorMessageConverter.convertToUserFriendlyMessage(underlyingError)
+        )
+    }
+
+    @MainActor
+    func testToggleOnSuccessClearsPreviousErrorMessage() async {
+        // Given: 直前のスケジュール失敗で errorMessage がセットされている
+        mockService.authorizationResult = true
+        mockService.scheduleDailyError = NSError(domain: "test", code: 1)
+        await viewModel.toggleNotification(enabled: true)
+        XCTAssertNotNil(viewModel.errorMessage)
+
+        // When: 再度有効化し、今度は成功する
+        mockService.scheduleDailyError = nil
+        await viewModel.toggleNotification(enabled: true)
+
+        // Then: errorMessage がクリアされる
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    @MainActor
+    func testClearErrorMessageResetsErrorMessage() async {
+        // Given: スケジュール失敗で errorMessage がセットされている
+        mockService.authorizationResult = true
+        mockService.scheduleDailyError = NSError(domain: "test", code: 1)
+        await viewModel.toggleNotification(enabled: true)
+        XCTAssertNotNil(viewModel.errorMessage)
+
+        // When: errorMessage をクリアする（View の alert dismiss から呼ばれる想定）
+        viewModel.clearErrorMessage()
+
+        // Then: errorMessage が nil に戻る
+        XCTAssertNil(viewModel.errorMessage)
     }
 
     // MARK: - 通知トグル OFF
@@ -190,6 +228,29 @@ final class NotificationSettingsViewModelTests: XCTestCase {
 
         // Then: リスケジュールが呼ばれる
         XCTAssertEqual(mockService.rescheduleCallCount, 1)
+    }
+
+    @MainActor
+    func testUpdateReminderTimeRescheduleErrorSetsUserFriendlyErrorMessage() async {
+        // Given: 通知が有効な状態で、リスケジュールが失敗する
+        mockService.isEnabled = true
+        let underlyingError = NSError(domain: "test", code: 2)
+        mockService.rescheduleError = underlyingError
+        let vm = NotificationSettingsViewModel(service: mockService)
+
+        var components = DateComponents()
+        components.hour = 7
+        components.minute = 0
+        let newTime = Calendar.current.date(from: components)!
+
+        // When: 時間を変更する
+        await vm.updateReminderTime(newTime)
+
+        // Then: ユーザー向けエラーメッセージがセットされる（silent failure 修正）
+        XCTAssertEqual(
+            vm.errorMessage,
+            ErrorMessageConverter.convertToUserFriendlyMessage(underlyingError)
+        )
     }
 
     @MainActor

--- a/app/OtetsudaiCoinTests/Presentation/ViewModels/PaymentReminderNotificationSettingsViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/ViewModels/PaymentReminderNotificationSettingsViewModelTests.swift
@@ -62,14 +62,48 @@ final class PaymentReminderNotificationSettingsViewModelTests: XCTestCase {
     @MainActor
     func testToggleOnRescheduleErrorRevertsState() async {
         mockService.authorizationResult = true
-        mockService.rescheduleError = NSError(domain: "test", code: 1)
+        let underlyingError = NSError(domain: "test", code: 1)
+        mockService.rescheduleError = underlyingError
         let vm = PaymentReminderNotificationSettingsViewModel(service: mockService)
 
         await vm.toggleNotification(enabled: true)
 
         XCTAssertFalse(vm.isEnabled)
         XCTAssertFalse(mockService.isEnabled)
-        XCTAssertNotNil(vm.scheduleError)
+        // Issue #144: scheduleError (Error) はどの View からも読まれておらず、
+        // 支払いリマインドのスケジュール失敗がユーザーに一切伝わらない silent failure だった。
+        // ユーザー向け文言 (ErrorMessageConverter 変換済み) を errorMessage に保持する。
+        XCTAssertEqual(
+            vm.errorMessage,
+            ErrorMessageConverter.convertToUserFriendlyMessage(underlyingError)
+        )
+    }
+
+    @MainActor
+    func testToggleOnSuccessClearsPreviousErrorMessage() async {
+        mockService.authorizationResult = true
+        mockService.rescheduleError = NSError(domain: "test", code: 1)
+        let vm = PaymentReminderNotificationSettingsViewModel(service: mockService)
+        await vm.toggleNotification(enabled: true)
+        XCTAssertNotNil(vm.errorMessage)
+
+        mockService.rescheduleError = nil
+        await vm.toggleNotification(enabled: true)
+
+        XCTAssertNil(vm.errorMessage)
+    }
+
+    @MainActor
+    func testClearErrorMessageResetsErrorMessage() async {
+        mockService.authorizationResult = true
+        mockService.rescheduleError = NSError(domain: "test", code: 1)
+        let vm = PaymentReminderNotificationSettingsViewModel(service: mockService)
+        await vm.toggleNotification(enabled: true)
+        XCTAssertNotNil(vm.errorMessage)
+
+        vm.clearErrorMessage()
+
+        XCTAssertNil(vm.errorMessage)
     }
 
     @MainActor
@@ -98,6 +132,25 @@ final class PaymentReminderNotificationSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(mockService.reminderHour, 7)
         XCTAssertEqual(mockService.reminderMinute, 45)
         XCTAssertEqual(mockService.rescheduleCallCount, 1)
+    }
+
+    @MainActor
+    func testUpdateReminderTimeRescheduleErrorSetsUserFriendlyErrorMessage() async {
+        mockService.isEnabled = true
+        let underlyingError = NSError(domain: "test", code: 2)
+        mockService.rescheduleError = underlyingError
+        let vm = PaymentReminderNotificationSettingsViewModel(service: mockService)
+
+        var comps = DateComponents()
+        comps.hour = 7
+        comps.minute = 45
+        let newTime = Calendar.current.date(from: comps)!
+        await vm.updateReminderTime(newTime)
+
+        XCTAssertEqual(
+            vm.errorMessage,
+            ErrorMessageConverter.convertToUserFriendlyMessage(underlyingError)
+        )
     }
 
     @MainActor

--- a/app/OtetsudaiCoinTests/Presentation/Views/NotificationSettingsViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Views/NotificationSettingsViewTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import SwiftUI
+@testable import OtetsudaiCoin
+
+@MainActor
+final class NotificationSettingsViewTests: XCTestCase {
+    private var mockReminderService: MockReminderNotificationService!
+    private var mockPaymentReminderService: MockPaymentReminderNotificationService!
+    private var viewModel: NotificationSettingsViewModel!
+    private var paymentViewModel: PaymentReminderNotificationSettingsViewModel!
+
+    override func setUp() {
+        super.setUp()
+        mockReminderService = MockReminderNotificationService()
+        mockPaymentReminderService = MockPaymentReminderNotificationService()
+        viewModel = NotificationSettingsViewModel(service: mockReminderService)
+        paymentViewModel = PaymentReminderNotificationSettingsViewModel(service: mockPaymentReminderService)
+    }
+
+    override func tearDown() {
+        paymentViewModel = nil
+        viewModel = nil
+        mockPaymentReminderService = nil
+        mockReminderService = nil
+        super.tearDown()
+    }
+
+    /// NotificationSettingsView がクラッシュなく初期化できることを確認 (smoke test)。
+    /// ViewInspector は Form + Toggle + DatePicker + .commonAlerts (chained .alert) の
+    /// 組み合わせを深く traverse できない可能性がある (既知制約、CLAUDE.md 参照) ため、
+    /// UI 構造の structural test は行わず、ロジックは ViewModel テストで網羅する (Issue #144)。
+    func test_notificationSettingsView_initializes_withoutCrash() {
+        _ = NotificationSettingsView(viewModel: viewModel, paymentViewModel: paymentViewModel)
+    }
+
+    /// errorMessage がセットされた状態でも View の初期化がクラッシュしないことを確認。
+    /// .commonAlerts の isPresented バインディングが errorMessage の有無で正しく分岐できることの
+    /// 間接的な担保（alert 表示状態自体は ViewInspector の制約で structural test 不可）。
+    func test_notificationSettingsView_initializes_withoutCrash_whenErrorMessagePresent() async {
+        mockReminderService.authorizationResult = true
+        mockReminderService.scheduleDailyError = NSError(domain: "test", code: 1)
+        await viewModel.toggleNotification(enabled: true)
+        XCTAssertNotNil(viewModel.errorMessage)
+
+        _ = NotificationSettingsView(viewModel: viewModel, paymentViewModel: paymentViewModel)
+    }
+}


### PR DESCRIPTION
Closes #144

## 概要

エラーを `print` だけで処理する catch ブロック（リリースビルドでは事実上の握りつぶし）を DebugLogger へ統一し、本丸である **通知スケジュール失敗の silent failure** をユーザー向け alert 表示に修正しました。

## 1. scheduleError の表出化（本丸・TDD）

### 問題

`NotificationSettingsViewModel` / `PaymentReminderNotificationSettingsViewModel` は catch で `scheduleError: Error?` に格納していましたが、**どの View も scheduleError を読んでいません**でした（`grep -rn scheduleError` で consumer ゼロを確認）。通知スケジュール失敗時、ユーザーには「なぜかトグルが有効にならない」だけが残る状態でした。

### 設計判断: scheduleError を errorMessage に「置換」（併設せず）

- `scheduleError` の外部 consumer は存在せず、参照は既存テストの `XCTAssertNotNil(scheduleError)` 2 件のみ → 生 `Error` を残す価値がないため併設ではなく置換
- `ErrorMessageConverter.convertToUserFriendlyMessage(_:)` で変換したユーザー向け文言を `errorMessage: String?` に格納（非 BaseViewModel 系の既存パターンである HomeViewModel 等の直呼びに準拠）
- `NotificationSettingsView` に既存の `CommonAlertModifier`（`.commonAlerts`）で alert 表示を追加。dismiss 用に `clearErrorMessage()` を追加
- **i18n**: ErrorMessageConverter の既存ローカライズ済み文言を再利用するため xcstrings への新規キー追加は不要

### TDD

- RED: `errorMessage` / `clearErrorMessage` 未定義のコンパイルエラーで `** TEST FAILED **` (exit=65) を確認してから実装（CLAUDE.md の skip 条件 (a) に該当するが実行して確認済み）
- 追加テスト: toggle 失敗時のユーザー向け文言セット / reschedule 失敗時のセット / 成功時のクリア / clearErrorMessage の 4 系統 × 2 VM
- View 側は ViewInspector 既知制約（Form + Toggle + DatePicker + chained .alert）のため structural test は書かず、smoke test（init crash なし、errorMessage セット状態含む）で担保

## 2. print → DebugLogger 置換一覧

| ファイル:行 (置換前) | 置換後 | レベル |
|---|---|---|
| ContentView.swift:173（支払いリマインド reschedule エラー） | `DebugLogger.error` | error |
| ContentView.swift:176（初期データセットアップエラー） | `DebugLogger.error` | error |
| SoundService.swift:74（audio session setup 失敗） | `DebugLogger.error` | error（音は非致命、ログのみ） |
| SoundService.swift:83（sound preload 失敗） | `DebugLogger.error` | error（同上） |
| Persistence.swift:108（Core Data エラー詳細） | `DebugLogger.error` | error ※呼び出し側 `#if DEBUG` ガードは削除（DebugLogger 内部で分岐、release でも os.Logger に詳細が残るよう改善） |
| SampleDataService.swift:89-92（生成サマリ、4 行 → 1 行に集約） | `DebugLogger.debug` | debug |
| SampleDataService.swift:115（全削除） | `DebugLogger.debug` | debug |
| SampleDataService.swift:125（記録のみ削除） | `DebugLogger.debug` | debug |
| SplashScreenView.swift:162（#Preview 内） | `DebugLogger.debug` | debug |

### 置換後の残存 print( （すべて意図的な除外）

```
app/OtetsudaiCoin/Utils/DebugLogger.swift:31                             … ロガー本体の正規実装
app/OtetsudaiCoin/Data/Repositories/InMemoryAllowancePaymentRepository.swift:97,106 … #142 がファイルごと削除中
app/OtetsudaiCoin/Presentation/ViewModels/HelpHistoryViewModel.swift:44  … #145 が全面リファクタ中（deinit print も #145 の担当）
```

## テスト結果

`xcodebuild test -only-testing:` で以下 6 suite を実行、`** TEST SUCCEEDED **`（log 末尾 `exit=0` を grep で確認）:

- NotificationSettingsViewModelTests（新規 3 件含む）
- PaymentReminderNotificationSettingsViewModelTests（新規 3 件含む）
- NotificationSettingsViewTests（新規 smoke 2 件）
- PersistenceControllerTests / SampleDataServiceTests / SoundServiceTests（print 置換ファイルの既存テスト、regression なし）

## Findings（out-of-scope、本 PR では修正せず）

1. **SettingsView.swift:342,375,411 の catch ブロック**: 調査の結果、**ユーザーに失敗は伝わっています**（3 箇所とも `sampleDataAlertMessage` に失敗メッセージをセットし `showingSampleDataAlert = true` で alert 表示）。silent failure ではないため対応不要。ただし文言が `error.localizedDescription` 直埋めで ErrorMessageConverter 未経由（技術的な文言がそのまま出る可能性）。DEBUG 限定の開発者向け機能のため優先度は低い。
2. **MonthlySummaryViewModel.swift:179-181**: エラー時 `snapshot = nil` のみでメッセージなし。表示側の形が異なるため今回スコープ外（#145 のスコープ外判断と整合）。ログすら残らないため、将来 `DebugLogger.error` 追加の余地あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkzYkR4vbpodVsKLDSy7BN