### PR TITLE
refactor(#145): ViewModel 状態管理を BaseViewModel 継承へ統一

### DIFF
--- a/app/OtetsudaiCoin/Presentation/ViewModels/ChildManagementViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/ChildManagementViewModel.swift
@@ -1,8 +1,7 @@
 import Foundation
-import Combine
-
 
 @MainActor
+@Observable
 class ChildManagementViewModel: BaseViewModel {
     var children: [Child] = []
     

--- a/app/OtetsudaiCoin/Presentation/ViewModels/HelpHistoryViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/HelpHistoryViewModel.swift
@@ -1,21 +1,18 @@
 import Foundation
-import Combine
 
 @MainActor
 @Observable
-class HelpHistoryViewModel {
+class HelpHistoryViewModel: BaseViewModel {
     var helpRecords: [HelpRecordWithDetails] = []
     var selectedChild: Child?
     var selectedPeriod: HistoryPeriod = .last3Months
-    var isLoading: Bool = false
-    var errorMessage: String?
-    
+    // isLoading / errorMessage は BaseViewModel から継承（successMessage も継承するが本 VM では未使用）
+
     private let helpRecordRepository: HelpRecordRepository
     private let helpTaskRepository: HelpTaskRepository
     private let childRepository: ChildRepository
-    private var cancellables: Set<AnyCancellable> = []
     private var loadHistoryTask: Task<Void, Never>?
-    
+
     init(
         helpRecordRepository: HelpRecordRepository,
         helpTaskRepository: HelpTaskRepository,
@@ -24,35 +21,32 @@ class HelpHistoryViewModel {
         self.helpRecordRepository = helpRecordRepository
         self.helpTaskRepository = helpTaskRepository
         self.childRepository = childRepository
-        
-        // SwiftUIの宣言的な仕組み：データ更新の自動監視
-        NotificationCenter.default
-            .publisher(for: .helpRecordUpdated)
-            .sink { [weak self] _ in
-                Task { @MainActor in
-                    self?.loadHelpHistory()
-                }
-            }
-            .store(in: &cancellables)
+        super.init()
 
         // 初期データは View 側の .task で loadInitialData() を明示呼び出しする責務に変更（#32）
     }
-    
-    deinit {
-        // 循環参照を避けるため、deinit内では何もしない
-        // タスクは自動的にキャンセルされ、cancellablesは自動的にクリーンアップされる
-        print("HelpHistoryViewModel deinit called")
+
+    // データ更新の自動監視（BaseViewModel.init から呼ばれる）。
+    // 手書きの NotificationCenter 購読を NotificationManager の observe* ヘルパへ統一。
+    override func setupNotificationListeners() {
+        NotificationManager.shared.observeHelpRecordUpdates(
+            action: { [weak self] in
+                Task { @MainActor in
+                    self?.loadHelpHistory()
+                }
+            },
+            cancellables: &cancellables
+        )
     }
-    
+
     func loadHelpHistory() {
         guard let child = selectedChild else { return }
         
         // 実行中のタスクをキャンセル
         loadHistoryTask?.cancel()
-        
-        isLoading = true
-        errorMessage = nil
-        
+
+        setLoading(true)
+
         loadHistoryTask = Task {
             do {
                 let dateRange = selectedPeriod.dateRange
@@ -82,11 +76,10 @@ class HelpHistoryViewModel {
                 guard !Task.isCancelled else { return }
                 
                 helpRecords = recordsWithDetails
-                isLoading = false
+                setLoading(false)
             } catch {
                 guard !Task.isCancelled else { return }
-                errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
-                isLoading = false
+                setUserFriendlyError(error)
             }
         }
     }
@@ -114,18 +107,14 @@ class HelpHistoryViewModel {
             do {
                 try await helpRecordRepository.delete(recordId)
                 loadHelpHistory()
-                // データ更新通知
-                NotificationCenter.default.post(name: .helpRecordUpdated, object: nil)
+                // データ更新通知（NotificationManager 経由に統一）
+                NotificationManager.shared.notifyHelpRecordUpdated()
             } catch {
-                errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
+                setUserFriendlyError(error)
             }
         }
     }
-    
-    func clearErrorMessage() {
-        errorMessage = nil
-    }
-    
+
     // MARK: - 初期データ読み込み
     
     /// 初期データの読み込み（最初の子供を自動選択）
@@ -142,7 +131,7 @@ class HelpHistoryViewModel {
                 loadHelpHistory()
             }
         } catch {
-            errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
+            setUserFriendlyError(error)
         }
     }
 }

--- a/app/OtetsudaiCoin/Presentation/ViewModels/HelpRecordEditViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/HelpRecordEditViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Combine
 
 @MainActor
 @Observable

--- a/app/OtetsudaiCoin/Presentation/ViewModels/HomeViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/HomeViewModel.swift
@@ -1,9 +1,8 @@
 import Foundation
-import Combine
 
 @MainActor
 @Observable
-class HomeViewModel {
+class HomeViewModel: BaseViewModel {
     var children: [Child] = []
     var selectedChild: Child?
     var monthlyAllowance: Int = 0
@@ -11,26 +10,23 @@ class HomeViewModel {
     var consecutiveDays: Int = 0
     var totalRecordsThisMonth: Int = 0
     var isCurrentMonthPaid: Bool = false
-    var isLoading: Bool = false
-    var errorMessage: String?
-    var successMessage: String?
-    
+    // isLoading / errorMessage / successMessage は BaseViewModel から継承
+
     // 未支払い警告機能
     var unpaidPeriods: [UnpaidPeriod] = []
     var hasUnpaidAllowances: Bool = false
     var showUnpaidWarning: Bool = false
     var unpaidWarningMessage: String?
     var totalUnpaidAmount: Int = 0
-    
+
     private let childRepository: ChildRepository
     private let helpRecordRepository: HelpRecordRepository
     private let helpTaskRepository: HelpTaskRepository
     private let allowanceCalculator: AllowanceCalculator
     private let allowancePaymentRepository: AllowancePaymentRepository
     private let unpaidDetector: UnpaidAllowanceDetectorService
-    private var cancellables: Set<AnyCancellable> = []
     private(set) var refreshDataTask: Task<Void, Never>?
-    
+
     init(
         childRepository: ChildRepository,
         helpRecordRepository: HelpRecordRepository,
@@ -45,8 +41,11 @@ class HomeViewModel {
         self.allowanceCalculator = allowanceCalculator
         self.allowancePaymentRepository = allowancePaymentRepository
         self.unpaidDetector = unpaidDetector
-        
-        // NotificationManagerを使用してデータ更新を自動監視
+        super.init()
+    }
+
+    // NotificationManagerを使用してデータ更新を自動監視（BaseViewModel.init から呼ばれる）
+    override func setupNotificationListeners() {
         NotificationManager.shared.observeHelpRecordUpdates(
             action: { [weak self] in
                 Task { @MainActor in
@@ -55,7 +54,7 @@ class HomeViewModel {
             },
             cancellables: &cancellables
         )
-        
+
         NotificationManager.shared.observeChildrenUpdates(
             action: { [weak self] in
                 Task { @MainActor in
@@ -65,7 +64,7 @@ class HomeViewModel {
             cancellables: &cancellables
         )
     }
-    
+
     // deinitでは@MainActorプロパティにアクセスできないため削除
     // タスクはViewModelのライフサイクルとともに自動的にキャンセルされる
     
@@ -78,8 +77,7 @@ class HomeViewModel {
     // #44: View 側の `.task` から明示的に await できる async 版。
     // 内部の `Task { }` を経由しないため、SwiftUI の `.task` ライフサイクルでキャンセル制御できる。
     func loadChildrenAsync() async {
-        isLoading = true
-        errorMessage = nil
+        setLoading(true)
 
         do {
             let loadedChildren = try await childRepository.findAll()
@@ -90,10 +88,9 @@ class HomeViewModel {
                 await checkUnpaidAllowances()
             }
 
-            isLoading = false
+            setLoading(false)
         } catch {
-            errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
-            isLoading = false
+            setUserFriendlyError(error)
         }
     }
     
@@ -116,48 +113,46 @@ class HomeViewModel {
         // 実行中のタスクをキャンセル
         refreshDataTask?.cancel()
         
-        isLoading = true
-        errorMessage = nil
-        
+        setLoading(true)
+
         refreshDataTask = Task {
             do {
                 // 処理開始時の選択された子供を保持
                 let processChild = child
-                
+
                 // データ取得を並行処理で高速化
                 async let recordsTask = helpRecordRepository.findByChildIdInCurrentMonth(processChild.id)
                 async let tasksTask = helpTaskRepository.findAll()
                 async let paymentTask = getCurrentMonthPayment(for: processChild.id)
-                
+
                 let records = try await recordsTask
                 let tasks = try await tasksTask
                 let payment = try await paymentTask
-                
+
                 // タスクがキャンセルされていないか、選択された子供が変更されていないか確認
-                guard !Task.isCancelled, selectedChild?.id == processChild.id else { 
-                    isLoading = false
-                    return 
+                guard !Task.isCancelled, selectedChild?.id == processChild.id else {
+                    setLoading(false)
+                    return
                 }
-                
+
                 // プロセスが正常に完了したことを確認
                 guard !records.isEmpty || !tasks.isEmpty else {
                     // データが空の場合でも正常な状態として扱う
                     updateDisplayValues(records: [], tasks: [], payment: payment)
-                    isLoading = false
+                    setLoading(false)
                     return
                 }
-                
+
                 // 計算処理を分離
                 updateDisplayValues(records: records, tasks: tasks, payment: payment)
-                isLoading = false
-                
+                setLoading(false)
+
             } catch {
-                guard !Task.isCancelled else { 
-                    isLoading = false
-                    return 
+                guard !Task.isCancelled else {
+                    setLoading(false)
+                    return
                 }
-                errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
-                isLoading = false
+                setUserFriendlyError(error)
             }
         }
     }
@@ -199,11 +194,11 @@ class HomeViewModel {
     
     func payMonthlyAllowance() {
         guard selectedChild != nil else {
-            errorMessage = String(localized: "子供が選択されていません")
+            setError(String(localized: "子供が選択されていません"))
             return
         }
-        
-        let amountToPay = isCurrentMonthPaid ? 
+
+        let amountToPay = isCurrentMonthPaid ?
             (currentMonthEarnings - monthlyAllowance) : currentMonthEarnings
         
         recordAllowancePayment(amount: amountToPay)
@@ -211,14 +206,14 @@ class HomeViewModel {
     
     func recordAllowancePayment(amount: Int) {
         guard let child = selectedChild else {
-            errorMessage = String(localized: "子供が選択されていません")
+            setError(String(localized: "子供が選択されていません"))
             return
         }
-        
-        isLoading = true
-        errorMessage = nil
-        successMessage = nil
-        
+
+        // BaseViewModel の setLoading(true) は errorMessage をクリアする（successMessage は保持）。
+        // 移行前は successMessage も明示クリアしていたが、統一のため基底セマンティクスを採用する。
+        setLoading(true)
+
         Task {
             do {
                 // 処理開始時の選択された子供を保持
@@ -245,11 +240,11 @@ class HomeViewModel {
                         
                         // UI更新前に選択された子供が変更されていないか確認
                         guard selectedChild?.id == processChild.id else {
-                            isLoading = false
+                            setLoading(false)
                             return
                         }
-                        
-                        successMessage = "\(processChild.name)に追加で\(amount)コインのお小遣いを渡しました"
+
+                        setSuccess("\(processChild.name)に追加で\(amount)コインのお小遣いを渡しました")
                     }
                 } else {
                     // 新規支払いの場合
@@ -263,37 +258,31 @@ class HomeViewModel {
                     
                     // UI更新前に選択された子供が変更されていないか確認
                     guard selectedChild?.id == processChild.id else {
-                        isLoading = false
+                        setLoading(false)
                         return
                     }
-                    
+
                     isCurrentMonthPaid = true
-                    successMessage = "\(processChild.name)に\(amount)コインのお小遣いを渡しました"
+                    setSuccess("\(processChild.name)に\(amount)コインのお小遣いを渡しました")
                 }
-                isLoading = false
-                
+                setLoading(false)
+
                 // データを再読み込み
                 refreshData()
                 
                 // 他の画面にも通知
                 NotificationManager.shared.notifyHelpRecordUpdated()
-                
+
             } catch {
                 guard !Task.isCancelled else {
-                    isLoading = false
+                    setLoading(false)
                     return
                 }
-                errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
-                isLoading = false
+                setUserFriendlyError(error)
             }
         }
     }
-    
-    func clearMessages() {
-        errorMessage = nil
-        successMessage = nil
-    }
-    
+
     // MARK: - 未支払い警告機能
     
     func checkUnpaidAllowances() async {
@@ -330,10 +319,10 @@ class HomeViewModel {
             }
 
         } catch {
-            errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
+            setUserFriendlyError(error)
         }
     }
-    
+
     func dismissUnpaidWarning() {
         showUnpaidWarning = false
     }

--- a/app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/RecordViewModel.swift
@@ -1,6 +1,4 @@
 import Foundation
-import Combine
-
 
 @MainActor
 @Observable

--- a/app/OtetsudaiCoin/Presentation/ViewModels/TaskManagementViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/TaskManagementViewModel.swift
@@ -2,11 +2,9 @@ import Foundation
 
 @MainActor
 @Observable
-class TaskManagementViewModel {
+class TaskManagementViewModel: BaseViewModel {
     var tasks: [HelpTask] = []
-    var isLoading: Bool = false
-    var errorMessage: String?
-    var successMessage: String?
+    // isLoading / errorMessage / successMessage は BaseViewModel から継承
 
     /// 「よく使う順に並べ替え」が意味を持つか。0/1 件では並べ替え不要 (#130-③)。
     var canSortByFrequency: Bool {
@@ -21,14 +19,14 @@ class TaskManagementViewModel {
     init(helpTaskRepository: HelpTaskRepository, helpRecordRepository: HelpRecordRepository) {
         self.helpTaskRepository = helpTaskRepository
         self.helpRecordRepository = helpRecordRepository
+        super.init()
     }
 
     func loadTasks() async {
         // 実行中のタスクをキャンセル
         loadTasksTask?.cancel()
 
-        isLoading = true
-        errorMessage = nil
+        setLoading(true)
 
         loadTasksTask = Task {
             do {
@@ -39,11 +37,10 @@ class TaskManagementViewModel {
 
                 // repository が (sortOrder, name) ソート済みを返す契約のため再ソート不要
                 tasks = allTasks
-                isLoading = false
+                setLoading(false)
             } catch {
                 guard !Task.isCancelled else { return }
-                errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
-                isLoading = false
+                setUserFriendlyError(error)
             }
         }
 
@@ -53,12 +50,12 @@ class TaskManagementViewModel {
 
     func addTask(name: String, coinRate: Int = 10) async {
         guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            errorMessage = String(localized: "タスク名を入力してください")
+            setError(String(localized: "タスク名を入力してください"))
             return
         }
 
         guard coinRate > 0 else {
-            errorMessage = String(localized: "コイン単価は1以上で入力してください")
+            setError(String(localized: "コイン単価は1以上で入力してください"))
             return
         }
 
@@ -66,7 +63,7 @@ class TaskManagementViewModel {
 
         // 重複チェック
         if tasks.contains(where: { $0.name == trimmedName }) {
-            errorMessage = String(localized: "同じ名前のタスクが既に存在します")
+            setError(String(localized: "同じ名前のタスクが既に存在します"))
             return
         }
 
@@ -82,30 +79,30 @@ class TaskManagementViewModel {
 
         do {
             try await helpTaskRepository.save(newTask)
-            successMessage = String(localized: "タスクを追加しました")
+            setSuccess(String(localized: "タスクを追加しました"))
             await loadTasks()
         } catch {
-            errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
+            setUserFriendlyError(error)
         }
     }
 
     func updateTask(_ task: HelpTask) async {
         do {
             try await helpTaskRepository.update(task)
-            successMessage = String(localized: "タスクを更新しました")
+            setSuccess(String(localized: "タスクを更新しました"))
             await loadTasks()
         } catch {
-            errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
+            setUserFriendlyError(error)
         }
     }
 
     func deleteTask(id: UUID) async {
         do {
             try await helpTaskRepository.delete(id)
-            successMessage = String(localized: "タスクを削除しました")
+            setSuccess(String(localized: "タスクを削除しました"))
             await loadTasks()
         } catch {
-            errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
+            setUserFriendlyError(error)
         }
     }
 
@@ -150,11 +147,11 @@ class TaskManagementViewModel {
                 // DB の再採番 (0..n-1) を in-memory にもミラーし、後続の toggle/編集が
                 // stale な sortOrder を書き戻すのを防ぐ
                 tasks = reordered.enumerated().map { $1.updatingSortOrder($0) }
-                errorMessage = nil // 先行する失敗永続化が残した errorMessage をクリア (#136)
+                clearErrorMessage() // 先行する失敗永続化が残した errorMessage をクリア (#136)
             } catch {
                 let message = ErrorMessageConverter.convertToUserFriendlyMessage(error)
                 await loadTasks() // DB の状態に巻き戻す
-                errorMessage = message // loadTasks 冒頭の errorMessage=nil に消されないよう reload 後にセット
+                setError(message) // loadTasks 冒頭の setLoading(true) による errorMessage クリアに消されないよう reload 後にセット
             }
         }
     }
@@ -178,7 +175,7 @@ class TaskManagementViewModel {
         do {
             records = try await helpRecordRepository.findByDateRange(from: windowStart, to: now)
         } catch {
-            errorMessage = ErrorMessageConverter.convertToUserFriendlyMessage(error)
+            setUserFriendlyError(error)
             return
         }
 
@@ -200,18 +197,14 @@ class TaskManagementViewModel {
                 try await helpTaskRepository.updateSortOrders(sorted.map(\.id))
                 // DB の再採番 (0..n-1) を in-memory にもミラー（moveTasks と同様）
                 tasks = sorted.enumerated().map { $1.updatingSortOrder($0) }
-                successMessage = String(localized: "よく使う順に並べ替えました")
-                errorMessage = nil // 先行する失敗永続化が残した errorMessage をクリア (#136)
+                // setSuccess は errorMessage もクリアするため、先行する失敗永続化が残した
+                // errorMessage の掃除も兼ねる (#136)
+                setSuccess(String(localized: "よく使う順に並べ替えました"))
             } catch {
                 let message = ErrorMessageConverter.convertToUserFriendlyMessage(error)
                 await loadTasks() // DB の状態に巻き戻す
-                errorMessage = message // loadTasks 冒頭の errorMessage=nil に消されないよう reload 後にセット
+                setError(message) // loadTasks 冒頭の setLoading(true) による errorMessage クリアに消されないよう reload 後にセット
             }
         }
-    }
-
-    func clearMessages() {
-        errorMessage = nil
-        successMessage = nil
     }
 }

--- a/app/OtetsudaiCoinTests/Presentation/HomeViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/HomeViewModelTests.swift
@@ -240,6 +240,71 @@ final class HomeViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showUnpaidWarning)
     }
     
+    // MARK: - recordAllowancePayment（#145 移行に伴い最終状態を固定する characterization tests）
+
+    @MainActor
+    func testRecordAllowancePaymentWithoutChildSetsErrorMessage() {
+        // Given: 子供未選択
+
+        // When
+        viewModel.recordAllowancePayment(amount: 100)
+
+        // Then: 同期 guard で即エラー
+        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertTrue(mockAllowancePaymentRepository.payments.isEmpty)
+    }
+
+    @MainActor
+    func testRecordAllowancePaymentNewPaymentSetsSuccessAndPaidFlag() async {
+        // Given: 子供選択済み・当月支払いなし（新規支払い経路）
+        let child = Child(id: UUID(), name: "太郎", themeColor: "#FF5733")
+        viewModel.selectedChild = child
+
+        // When
+        viewModel.recordAllowancePayment(amount: 150)
+
+        // 非同期処理の完了を待機
+        let expectation = XCTestExpectation(description: "Record allowance payment")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        // Then: 支払いが保存され、成功メッセージと支払い済みフラグが立つ
+        XCTAssertEqual(mockAllowancePaymentRepository.payments.count, 1)
+        XCTAssertEqual(mockAllowancePaymentRepository.payments.first?.amount, 150)
+        XCTAssertTrue(viewModel.isCurrentMonthPaid)
+        XCTAssertNotNil(viewModel.successMessage)
+        XCTAssertTrue(viewModel.successMessage!.contains("太郎"))
+        XCTAssertTrue(viewModel.successMessage!.contains("150"))
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    @MainActor
+    func testRecordAllowancePaymentFailureSetsErrorMessageAndStopsLoading() async {
+        // Given: 保存が失敗する
+        let child = Child(id: UUID(), name: "太郎", themeColor: "#FF5733")
+        viewModel.selectedChild = child
+        mockAllowancePaymentRepository.shouldThrowError = true
+
+        // When
+        viewModel.recordAllowancePayment(amount: 150)
+
+        // 非同期処理の完了を待機
+        let expectation = XCTestExpectation(description: "Record allowance payment failure")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        // Then: エラーメッセージがセットされ、ローディングは終了する
+        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertFalse(viewModel.isCurrentMonthPaid)
+        XCTAssertNil(viewModel.successMessage)
+    }
+
     @MainActor
     private func createViewModelWithUnpaidDetector(unpaidDetector: UnpaidAllowanceDetectorService) -> HomeViewModel {
         return HomeViewModel(

--- a/app/OtetsudaiCoinTests/Presentation/ViewModels/ViewModelObservationTrackingTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/ViewModels/ViewModelObservationTrackingTests.swift
@@ -78,4 +78,28 @@ final class ViewModelObservationTrackingTests: XCTestCase {
             "RecordViewModel.selectedChild（@Observable 再付与済みサブクラス）が追跡されていない。"
         )
     }
+
+    // MARK: - HomeViewModel（#145 で BaseViewModel 継承へ移行した VM）
+
+    /// 移行後の VM でもサブクラス宣言プロパティ `children` が追跡されることを回帰ガードとして固定する。
+    func testHomeViewModelSubclassPropertyIsObservable() {
+        let viewModel = HomeViewModel(
+            childRepository: MockChildRepository(),
+            helpRecordRepository: MockHelpRecordRepository(),
+            helpTaskRepository: MockHelpTaskRepository(),
+            allowanceCalculator: MockAllowanceCalculator(),
+            allowancePaymentRepository: MockAllowancePaymentRepository()
+        )
+        let child = Child(id: UUID(), name: "次郎", themeColor: "#3357FF")
+
+        let fired = assertTracksMutation(
+            access: { _ = viewModel.children },
+            mutate: { viewModel.children = [child] }
+        )
+
+        XCTAssertTrue(
+            fired,
+            "HomeViewModel.children（BaseViewModel 継承へ移行後）が追跡されていない。"
+        )
+    }
 }

--- a/app/OtetsudaiCoinTests/Presentation/ViewModels/ViewModelObservationTrackingTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/ViewModels/ViewModelObservationTrackingTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import Observation
+@testable import OtetsudaiCoin
+
+/// `BaseViewModel` を継承した ViewModel の「サブクラスで新規宣言した stored property」が
+/// Observation で追跡されるか（= SwiftUI View が再描画されるか）を検証する。
+///
+/// 通常の ViewModel テストはプロパティを直接読むため observation の有無に関わらず PASS してしまい、
+/// 壊れた SwiftUI reactivity を検知できない。`withObservationTracking` のみがこれを判別できる。
+///
+/// 検証対象は **必ずサブクラスで宣言したプロパティ**にする。`isLoading` / `errorMessage` は
+/// 基底 `BaseViewModel` の `@Observable` マクロが変換済みで、サブクラス側の `@Observable` 付与有無に
+/// 関わらず常に追跡されるため、判別材料にならない（false "動いている" を生む）。
+///
+/// #145: `@Observable` を継承サブクラスへ再付与する必要があるか（付与しないと新規 stored property が
+/// 追跡されないか）を実証し、全継承 VM で付与を統一する根拠とする。
+@MainActor
+final class ViewModelObservationTrackingTests: XCTestCase {
+
+    /// サブクラスで宣言したプロパティ変更で `onChange` が同期発火することを確認するヘルパ。
+    /// `withObservationTracking(_:onChange:)` は apply クロージャで access したプロパティの
+    /// 最初の `willSet` で `onChange` を **同期**発火する（非同期待ち不要 = flake しない）。
+    private func assertTracksMutation(
+        access: () -> Void,
+        mutate: () -> Void
+    ) -> Bool {
+        var fired = false
+        withObservationTracking {
+            access()
+        } onChange: {
+            fired = true
+        }
+        mutate()
+        return fired
+    }
+
+    // MARK: - ChildManagementViewModel（サブクラスで `children` を宣言）
+
+    /// `ChildManagementViewModel.children` はサブクラス宣言プロパティ。
+    /// `@Observable` がサブクラスに付与されていれば追跡され、View が更新される。
+    func testChildManagementViewModelChildrenIsObservable() {
+        let viewModel = ChildManagementViewModel(childRepository: MockChildRepository())
+        let child = Child(id: UUID(), name: "太郎", themeColor: "#FF5733")
+
+        let fired = assertTracksMutation(
+            access: { _ = viewModel.children },
+            mutate: { viewModel.children = [child] }
+        )
+
+        XCTAssertTrue(
+            fired,
+            "ChildManagementViewModel.children の変更が Observation で追跡されていない。"
+            + "サブクラスの新規 stored property は @Observable 再付与がないと追跡されず、"
+            + "SwiftUI View が再描画されない（#145 の分裂で生じた潜在的 reactivity ギャップ）。"
+        )
+    }
+
+    // MARK: - RecordViewModel（既に `@Observable` 再付与済み・対照群）
+
+    /// `RecordViewModel` は既にサブクラスへ `@Observable` を再付与している。
+    /// サブクラス宣言プロパティ `selectedChild` が追跡されることを対照群として確認する。
+    func testRecordViewModelSubclassPropertyIsObservable() {
+        let viewModel = RecordViewModel(
+            childRepository: MockChildRepository(),
+            helpTaskRepository: MockHelpTaskRepository(),
+            helpRecordRepository: MockHelpRecordRepository(),
+            soundService: MockSoundService()
+        )
+        let child = Child(id: UUID(), name: "花子", themeColor: "#33FF57")
+
+        let fired = assertTracksMutation(
+            access: { _ = viewModel.selectedChild },
+            mutate: { viewModel.selectedChild = child }
+        )
+
+        XCTAssertTrue(
+            fired,
+            "RecordViewModel.selectedChild（@Observable 再付与済みサブクラス）が追跡されていない。"
+        )
+    }
+}


### PR DESCRIPTION
## 概要

Closes #145

ViewModel の状態管理パターンが「BaseViewModel 継承 3 本 / 独立 6 本」に分裂していた問題を解消し、`isLoading` / `errorMessage` / `successMessage` を手書きで再現していた独立 VM 3 本を BaseViewModel 継承へ統一しました。

## 変更内容

### 1. BaseViewModel 継承への移行（3 本）

| ViewModel | 移行内容 |
|---|---|
| `HomeViewModel` | 手書き 3 状態 + 独自 `clearMessages()` を削除し、直代入を `setLoading` / `setError` / `setSuccess` / `setUserFriendlyError` へ置換。NotificationManager 購読を `setupNotificationListeners()` override へ移動 |
| `TaskManagementViewModel` | 同上。#136 の「reload 後にメッセージを再セットする順序制御」は完全維持（既存テスト 2 本が gate していることを確認） |
| `HelpHistoryViewModel` | 手書き 2 状態 + 独自 `clearErrorMessage()` を削除。手書き `NotificationCenter.publisher.sink` を `NotificationManager.observeHelpRecordUpdates` ヘルパへ統一（唯一の例外だった手書き購読を解消）、`deleteRecord` 内の直接 post も `notifyHelpRecordUpdated()` へ統一。`deinit` の `print` を削除 |

### 2. @Observable 再付与ルールの実証と統一

**結論: BaseViewModel を継承するサブクラスには `@Observable` を必ず再付与する。**

`withObservationTracking` を使った検証テスト（`ViewModelObservationTrackingTests`、新規）で実証しました:

- `RecordViewModel`（`@Observable` 再付与済み）: サブクラス宣言プロパティ `selectedChild` の変更が追跡される → **PASS**
- `ChildManagementViewModel`（再付与なし・修正前）: サブクラス宣言プロパティ `children` の変更が**追跡されない** → **FAIL**（1 コミット目で RED を記録 → 2 コミット目の `@Observable` 付与で GREEN）

つまりサブクラスに `@Observable` を付与しないと、基底クラス宣言の `isLoading` 等は追跡される一方で**サブクラス新規宣言の stored property が Observation 追跡から漏れ、SwiftUI View が再描画されません**。`ChildManagementViewModel` は移行前からこの潜在的 reactivity ギャップを持っていました（通常の unit test はプロパティを直接読むため検知不能）。`withObservationTracking` テストを回帰ガードとして恒久追加しています（移行後 `HomeViewModel` の追跡確認も含む 3 本）。

CLAUDE.md への「@Observable 再付与ルール」追記は本 PR に含めず、別 issue に委ねます（本 PR は description への記載のみ）。

### 3. 死んだ `import Combine` の削除

`RecordViewModel` / `HelpRecordEditViewModel` / `ChildManagementViewModel`（Combine シンボル未使用） / `HomeViewModel` / `HelpHistoryViewModel`（cancellables を基底へ集約 / 購読をヘルパ経由へ統一したため不要化）から削除。ビルド + テスト green で不要を実証済み。残る `import Combine` は `BaseViewModel`（`AnyCancellable` 使用）と `NotificationManager`（`publisher` 使用）の 2 ファイルのみ。

## スコープ外（意図的に移行しない VM）

- **`MonthlySummaryViewModel`**: エラー時 snapshot=nil という状態の形自体が異なり、3 状態モデルを持たない。無理に継承させると未使用の状態が増えるだけで統一の利益がない。
- **`NotificationSettingsViewModel` / `PaymentReminderNotificationSettingsViewModel`**: `scheduleError: Error?` のみの軽量状態で、こちらも形が異なる。加えて #144（print → DebugLogger 統一）が並行作業中のため触らない。

issue 受け入れ条件の補足: 調査の結果 **ObservableObject / @Published は既に 0 件**で（issue 起票時の記載から状況が進んでいた）、実際の分裂は「BaseViewModel 継承 vs 手書き状態の独立 VM」でした。BaseViewModel 自体は既に `@Observable` であり、protocol/composition への全面移行はスコープ過剰と判断して「同義の手書き状態を継承へ集約する」方向で統一しています。

## 挙動差分（移行に伴う既知のセマンティクス変化）

- `setLoading(true)` は `errorMessage` をクリアする（CLAUDE.md 記載の既知挙動）。移行した 3 VM は元コードでもロード開始時に `errorMessage = nil` を明示していたため**実質同一**。
- `HomeViewModel.recordAllowancePayment` は移行前、開始時に `successMessage = nil` も明示クリアしていたが、`setLoading(true)` は successMessage を保持する。**最終状態は不変**（成功時は `setSuccess` が上書き、失敗時は `setError` がクリア）で、差分は非同期処理中の一瞬だけ旧 successMessage が残ること。characterization テスト 3 本で最終状態を固定済み。
- `TaskManagementViewModel.sortByFrequency` 成功時: `successMessage = ...; errorMessage = nil` → `setSuccess(...)` へ置換（setSuccess は errorMessage もクリアするため #136 の意図を単一 API で充足）。`isLoading = false` の副作用が加わるが、この経路で isLoading は常に false のため実質不変。

## テスト

- 対象 6 suite + 新規 `ViewModelObservationTrackingTests` を `xcodebuild test -only-testing:`（iPhone 17 simulator）で実行し **`** TEST SUCCEEDED **`（real exit 0、log の `REAL_EXIT=` 行で確認）**。
- characterization テスト 3 本は **移行前のコードに対しても green** であることを stash を使って実証済み（真に挙動を固定するテストであることの確認）。
- ChildManagementViewModel の observation ギャップは RED（コミット 2142c61 時点）→ GREEN（bafb599）を実測。

## Plan からの逸脱

なし（オーケストレーター確定設計に従った）。TDD の red 実証は「ChildManagementViewModel の observation ギャップ」で実施。characterization テストは refactor の性質上 old/new 両方 green が正であり、stash による old-code green 確認で red 相当の実証を代替した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkzYkR4vbpodVsKLDSy7BN
