### PR TITLE
fix(#151): タップ領域 44pt 未満とダークモードで沈む極薄塗りを修正（a11y サブセット）

### DIFF
--- a/app/OtetsudaiCoin/Presentation/Components/RecordCalendarView.swift
+++ b/app/OtetsudaiCoin/Presentation/Components/RecordCalendarView.swift
@@ -45,7 +45,8 @@ struct RecordCalendarView: View {
     private var header: some View {
         HStack {
             Button(action: onPrevMonth) {
-                Text("‹").font(.title2).frame(width: 44, height: 32)
+                // #151: HIG の最小タップ領域 44×44pt を満たす (以前は高さ 32pt)
+                Text("‹").font(.title2).frame(width: 44, height: 44)
             }
             .accessibilityIdentifier("calendar_prev_month")
             .accessibilityLabel(Text(String(localized: "前の月")))
@@ -55,7 +56,7 @@ struct RecordCalendarView: View {
             Spacer()
 
             Button(action: onNextMonth) {
-                Text("›").font(.title2).frame(width: 44, height: 32)
+                Text("›").font(.title2).frame(width: 44, height: 44)
                     .opacity(canGoNextMonth ? 1 : 0.3)
             }
             .disabled(!canGoNextMonth)

--- a/app/OtetsudaiCoin/Presentation/Components/TaskCardView.swift
+++ b/app/OtetsudaiCoin/Presentation/Components/TaskCardView.swift
@@ -110,7 +110,9 @@ struct TaskCardView: View {
 
     private var cardBackground: some View {
         RoundedRectangle(cornerRadius: AppRadius.large)
-            .fill(isSelected ? AccessibilityColors.brandPrimary.opacity(0.1) : Color.gray.opacity(0.05))
+            // #151: 未選択時は gray.opacity(0.05) だとダークモードで地に沈んで
+            // カードの境界が消える。ライト/ダークで明度が反転する適応色を使う。
+            .fill(isSelected ? AccessibilityColors.brandPrimary.opacity(0.1) : AccessibilityColors.systemBackgroundSecondary)
             .overlay(
                 RoundedRectangle(cornerRadius: AppRadius.large)
                     .stroke(isSelected ? AccessibilityColors.brandPrimary : Color.clear, lineWidth: 2)

--- a/app/OtetsudaiCoin/Presentation/Views/ChildCardView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/ChildCardView.swift
@@ -44,7 +44,8 @@ struct ChildCardView: View {
             .frame(width: 120)
             .background(
                 RoundedRectangle(cornerRadius: AppRadius.medium)
-                    .fill(isSelected ? themeColor.opacity(0.1) : Color.gray.opacity(0.05))
+                    // #151: 未選択時は gray.opacity(0.05) だとダークモードで地に沈むため適応色を使う
+                    .fill(isSelected ? themeColor.opacity(0.1) : AccessibilityColors.systemBackgroundSecondary)
                     .overlay(
                         RoundedRectangle(cornerRadius: AppRadius.medium)
                             .stroke(isSelected ? themeColor : Color.clear, lineWidth: 2)

--- a/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
@@ -340,7 +340,10 @@ struct HelpRecordRow: View {
             Spacer()
             
             // アクションボタン
-            HStack(spacing: 12) {
+            // #151: 各ボタンが 44pt 幅 (アイコン 16pt + 左右 14pt ずつの余白) を
+            // 持つようになったため、ボタン間の 12pt は視覚的に不要。4pt へ詰めて
+            // タスク名側の横幅を戻す (アイコン間の実距離は 32pt 確保される)。
+            HStack(spacing: 4) {
                 // 編集ボタン
                 // #151: アイコン実寸 (約 16pt) がそのままタップ領域だったため、
                 // HIG の最小 44×44pt まで広げる。contentShape で frame 全体を

--- a/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
@@ -342,18 +342,25 @@ struct HelpRecordRow: View {
             // アクションボタン
             HStack(spacing: 12) {
                 // 編集ボタン
+                // #151: アイコン実寸 (約 16pt) がそのままタップ領域だったため、
+                // HIG の最小 44×44pt まで広げる。contentShape で frame 全体を
+                // 当たり判定にする (frame だけではアイコンの形のまま)。
                 Button(action: onEdit) {
                     Image(systemName: "pencil")
                         .font(.system(size: 16))
                         .foregroundColor(.blue)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(PlainButtonStyle())
-                
+
                 // 削除ボタン
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .font(.system(size: 16))
                         .foregroundColor(.red)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(PlainButtonStyle())
             }

--- a/app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift
@@ -466,8 +466,11 @@ struct TutorialTaskCardView: View {
             .frame(height: 120)
             .background(
                 RoundedRectangle(cornerRadius: AppRadius.large)
-                    // #151: 実 UI の TaskCardView と同じ適応色に揃える (ダークモードで沈まない)
-                    .fill(isSelected ? AccessibilityColors.brandPrimary.opacity(0.1) : AccessibilityColors.systemBackgroundSecondary)
+                    // #151: このカードはグラデ背景 + .ultraThinMaterial パネル (:345) の上に
+                    // 乗っているため、不透明な systemBackgroundSecondary へ置き換えると
+                    // 透過表現を潰してしまう。Tutorial 画面のダークモード方針
+                    // (issue #151 本文「グラデ背景上の白文字は未検証」) が決まるまで据え置く。
+                    .fill(isSelected ? AccessibilityColors.brandPrimary.opacity(0.1) : Color.gray.opacity(0.05))
                     .overlay(
                         RoundedRectangle(cornerRadius: AppRadius.large)
                             .stroke(isSelected ? AccessibilityColors.brandPrimary : Color.clear, lineWidth: 2)

--- a/app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift
@@ -466,7 +466,8 @@ struct TutorialTaskCardView: View {
             .frame(height: 120)
             .background(
                 RoundedRectangle(cornerRadius: AppRadius.large)
-                    .fill(isSelected ? AccessibilityColors.brandPrimary.opacity(0.1) : Color.gray.opacity(0.05))
+                    // #151: 実 UI の TaskCardView と同じ適応色に揃える (ダークモードで沈まない)
+                    .fill(isSelected ? AccessibilityColors.brandPrimary.opacity(0.1) : AccessibilityColors.systemBackgroundSecondary)
                     .overlay(
                         RoundedRectangle(cornerRadius: AppRadius.large)
                             .stroke(isSelected ? AccessibilityColors.brandPrimary : Color.clear, lineWidth: 2)

--- a/app/OtetsudaiCoinTests/Presentation/Components/ChildCardViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/ChildCardViewTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import OtetsudaiCoin
+
+/// `ChildCardView`（ホームの子どもカード）のコンポーネントテスト。
+///
+/// `accessibilityIdentifier` は ViewInspector 0.10.2 + iOS 26 SDK で解決不能なため、
+/// 図形の色は `findAll(ViewType.Shape.self)` + `fillShapeStyle(Color.self)` で確認する
+/// (CLAUDE.md § SwiftUI View テスト戦略「findAll fallback」)。
+@MainActor
+final class ChildCardViewTests: XCTestCase {
+
+    private func makeChild(themeColor: String = "#FF6B6B") -> Child {
+        Child(id: UUID(), name: "さくら", themeColor: themeColor)
+    }
+
+    /// #151: 未選択カードの背景はダークモードで消えない適応色を使う。
+    ///
+    /// 修正前は `Color.gray.opacity(0.05)` の極薄塗りで、黒地ではほぼ見えず
+    /// カードの境界が失われていた。
+    func testUnselectedCardBackgroundUsesAdaptiveColor() throws {
+        let view = ChildCardView(child: makeChild(), isSelected: false, onTap: {})
+        let fills = try view.inspect().findAll(ViewType.Shape.self).compactMap { try? $0.fillShapeStyle(Color.self) }
+
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.systemBackgroundSecondary),
+            "未選択カードの背景が適応色でない / observed fills: \(fills)"
+        )
+        XCTAssertFalse(
+            fills.contains(Color.gray.opacity(0.05)),
+            "ダークモードで消える gray.opacity(0.05) が残っている / observed fills: \(fills)"
+        )
+    }
+
+    /// 選択時はテーマカラーの淡色が背景になる（適応色化で選択表現まで消していないこと）。
+    func testSelectedCardBackgroundUsesThemeColor() throws {
+        let themeHex = "#FF6B6B"
+        let view = ChildCardView(child: makeChild(themeColor: themeHex), isSelected: true, onTap: {})
+        let fills = try view.inspect().findAll(ViewType.Shape.self).compactMap { try? $0.fillShapeStyle(Color.self) }
+
+        let expected = (Color(hex: themeHex) ?? .blue).opacity(0.1)
+        XCTAssertTrue(
+            fills.contains(expected),
+            "選択カードの背景がテーマカラーの淡色でない / observed fills: \(fills)"
+        )
+    }
+}

--- a/app/OtetsudaiCoinTests/Presentation/Components/HelpRecordRowTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/HelpRecordRowTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import OtetsudaiCoin
+
+/// `HelpRecordRow`（履歴 1 行）のコンポーネントテスト。
+///
+/// 親の `HelpHistoryView` は NavigationStack + List + Image(systemName:) の
+/// 組み合わせで ViewInspector が traverse できないが、`HelpRecordRow` は
+/// トップレベル struct なので単独で検証できる
+/// (CLAUDE.md § SwiftUI View テスト戦略「Component 分離による blocker 回避」)。
+///
+/// `accessibilityIdentifier` は ViewInspector 0.10.2 + iOS 26 SDK で解決不能なため、
+/// `findAll(ViewType.Button.self)` ベースで掴む。
+@MainActor
+final class HelpRecordRowTests: XCTestCase {
+
+    private func makeView(
+        onEdit: @escaping () -> Void = {},
+        onDelete: @escaping () -> Void = {}
+    ) -> HelpRecordRow {
+        let child = Child(id: UUID(), name: "さくら", themeColor: "#FF6B6B")
+        let task = HelpTask(id: UUID(), name: "皿洗い", isActive: true, coinRate: 100)
+        let record = HelpRecord(
+            id: UUID(),
+            childId: child.id,
+            helpTaskId: task.id,
+            recordedAt: Calendar.current.date(from: DateComponents(year: 2026, month: 6, day: 15, hour: 12))!
+        )
+        return HelpRecordRow(
+            record: HelpRecordWithDetails(helpRecord: record, child: child, task: task),
+            onEdit: onEdit,
+            onDelete: onDelete
+        )
+    }
+
+    /// #151: 編集・削除ボタンは HIG の最小タップ領域 44×44pt を満たす。
+    ///
+    /// 修正前は明示 frame が無く、`Image(systemName:).font(.system(size: 16))` の
+    /// 実寸（約 16〜20pt）がそのままタップ領域だった。しかも 2 つが 12pt 間隔で
+    /// 横並びなので、押し間違いが起きやすい。
+    ///
+    /// 失敗時に観測値を dump し、「frame が読めない」のか「値が足りない」のかを
+    /// 再実行なしで切り分けられるようにする。
+    func test_editAndDeleteButtons_meetMinimumTapTargetSize() throws {
+        let minimumTapTarget: CGFloat = 44
+        let view = makeView()
+
+        let buttons = try view.inspect().findAll(ViewType.Button.self)
+        XCTAssertEqual(buttons.count, 2, "編集・削除の 2 ボタンが見つからない (buttons=\(buttons.count))")
+
+        // タップ領域は Button ではなく label 側の Image に付けている
+        // (contentShape と組で当たり判定を frame 全体へ広げるため)。
+        // Image は AccessibilityImageLabel blocker になるが、findAll なら列挙できる。
+        // frame を持たない兄弟 Image (行頭の hands.sparkles) は compactMap で落ちる。
+        let images = try view.inspect().findAll(ViewType.Image.self)
+        let frames = images.compactMap { try? $0.fixedFrame() }
+        XCTAssertEqual(
+            frames.count, 2,
+            "編集・削除アイコンの frame を 2 つ読めない (images=\(images.count) / frames=\(frames.map { ($0.width, $0.height) }))"
+        )
+
+        for frame in frames {
+            XCTAssertGreaterThanOrEqual(
+                frame.width ?? 0, minimumTapTarget,
+                "アクションボタンの幅が 44pt 未満 / frames: \(frames.map { ($0.width, $0.height) })"
+            )
+            XCTAssertGreaterThanOrEqual(
+                frame.height ?? 0, minimumTapTarget,
+                "アクションボタンの高さが 44pt 未満 / frames: \(frames.map { ($0.width, $0.height) })"
+            )
+        }
+    }
+
+    /// タップ領域を広げても、それぞれのボタンが正しいコールバックに繋がっている。
+    /// (frame を足す過程で onEdit / onDelete が入れ替わる事故を防ぐ)
+    func test_buttonsInvokeTheirOwnCallbacks() throws {
+        var edited = false
+        var deleted = false
+        let view = makeView(onEdit: { edited = true }, onDelete: { deleted = true })
+
+        let buttons = try view.inspect().findAll(ViewType.Button.self)
+        XCTAssertEqual(buttons.count, 2, "編集・削除の 2 ボタンが見つからない")
+
+        try buttons[0].tap()
+        XCTAssertTrue(edited, "1 つ目のボタンで onEdit が呼ばれない")
+        XCTAssertFalse(deleted, "1 つ目のボタンで onDelete まで呼ばれている")
+
+        try buttons[1].tap()
+        XCTAssertTrue(deleted, "2 つ目のボタンで onDelete が呼ばれない")
+    }
+}

--- a/app/OtetsudaiCoinTests/Presentation/Components/RecordCalendarViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/RecordCalendarViewTests.swift
@@ -154,6 +154,39 @@ final class RecordCalendarViewTests: XCTestCase {
         )
     }
 
+    /// #151: 月送り矢印は HIG の最小タップ領域 44×44pt を満たす。
+    ///
+    /// 修正前は `.frame(width: 44, height: 32)` で高さが 12pt 不足していた。
+    /// `fixedFrame()` による frame 取得はこのリポで初出のため、失敗時に
+    /// 観測値を dump して「機構が到達できなかった」のか
+    /// 「値が足りない」のかを再実行なしで切り分けられるようにする。
+    func test_monthNavButtons_meetMinimumTapTargetSize() throws {
+        let minimumTapTarget: CGFloat = 44
+        let view = makeView(canGoNextMonth: true)
+        let texts = try view.inspect().findAll(ViewType.Text.self)
+        let arrows = texts.filter { text in
+            guard let s = try? text.string() else { return false }
+            return s == "‹" || s == "›"
+        }
+        XCTAssertEqual(
+            arrows.count, 2,
+            "月送り矢印が 2 つ見つからない / rendered: \(texts.compactMap { try? $0.string() })"
+        )
+
+        let frames = arrows.compactMap { try? $0.fixedFrame() }
+        XCTAssertEqual(frames.count, 2, "矢印の frame を読めない (fixedFrame が到達不可)")
+        for frame in frames {
+            XCTAssertGreaterThanOrEqual(
+                frame.height ?? 0, minimumTapTarget,
+                "月送り矢印の高さが 44pt 未満 / frames: \(frames.map { ($0.width, $0.height) })"
+            )
+            XCTAssertGreaterThanOrEqual(
+                frame.width ?? 0, minimumTapTarget,
+                "月送り矢印の幅が 44pt 未満 / frames: \(frames.map { ($0.width, $0.height) })"
+            )
+        }
+    }
+
     /// 前月ボタンをタップすると onPrevMonth が呼ばれる。
     func test_tapPrevMonth_callsOnPrevMonth() throws {
         var called = false

--- a/app/OtetsudaiCoinTests/Presentation/Components/TaskCardViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/TaskCardViewTests.swift
@@ -122,4 +122,28 @@ final class TaskCardViewTests: XCTestCase {
         ]
         XCTAssertTrue(fills.contains { expected.contains($0) }, "observed fills: \(fills)")
     }
+
+    /// #151: 未選択カードの背景はダークモードで消えない適応色を使う。
+    ///
+    /// 修正前は `Color.gray.opacity(0.05)` の極薄塗りで、黒地ではほぼ見えず
+    /// カードの境界が失われていた。`systemBackgroundSecondary`
+    /// (`Color(.secondarySystemBackground)`) はライト/ダークで明度が反転するため
+    /// どちらでも地との差が残る。
+    ///
+    /// hex リテラル直書きではなくトークン定数と比較することで、
+    /// トークン側の値を変えたときにテストが追随する。
+    func testUnselectedCardBackgroundUsesAdaptiveColor() throws {
+        let view = TaskCardView(task: makeTask(), isSelected: false, onTap: {})
+        let shapes = try view.inspect().findAll(ViewType.Shape.self)
+        let fills = shapes.compactMap { try? $0.fillShapeStyle(Color.self) }
+
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.systemBackgroundSecondary),
+            "未選択カードの背景が適応色でない / observed fills: \(fills)"
+        )
+        XCTAssertFalse(
+            fills.contains(Color.gray.opacity(0.05)),
+            "ダークモードで消える gray.opacity(0.05) が残っている / observed fills: \(fills)"
+        )
+    }
 }

--- a/app/OtetsudaiCoinTests/Presentation/Components/TutorialTaskCardViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/TutorialTaskCardViewTests.swift
@@ -48,4 +48,20 @@ final class TutorialTaskCardViewTests: XCTestCase {
         ]
         XCTAssertTrue(fills.contains { expected.contains($0) }, "observed fills: \(fills)")
     }
+
+    /// #151: 未選択カードの背景は実 UI の TaskCardView と同じ適応色を使う。
+    /// チュートリアルの見本が実画面と違う見え方をしないよう揃える。
+    func testUnselectedCardBackgroundUsesAdaptiveColor() throws {
+        let view = TutorialTaskCardView(task: makeTask(), isSelected: false, onTap: {})
+        let fills = try view.inspect().findAll(ViewType.Shape.self).compactMap { try? $0.fillShapeStyle(Color.self) }
+
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.systemBackgroundSecondary),
+            "未選択カードの背景が適応色でない / observed fills: \(fills)"
+        )
+        XCTAssertFalse(
+            fills.contains(Color.gray.opacity(0.05)),
+            "ダークモードで消える gray.opacity(0.05) が残っている / observed fills: \(fills)"
+        )
+    }
 }

--- a/app/OtetsudaiCoinTests/Presentation/Components/TutorialTaskCardViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/TutorialTaskCardViewTests.swift
@@ -49,19 +49,4 @@ final class TutorialTaskCardViewTests: XCTestCase {
         XCTAssertTrue(fills.contains { expected.contains($0) }, "observed fills: \(fills)")
     }
 
-    /// #151: 未選択カードの背景は実 UI の TaskCardView と同じ適応色を使う。
-    /// チュートリアルの見本が実画面と違う見え方をしないよう揃える。
-    func testUnselectedCardBackgroundUsesAdaptiveColor() throws {
-        let view = TutorialTaskCardView(task: makeTask(), isSelected: false, onTap: {})
-        let fills = try view.inspect().findAll(ViewType.Shape.self).compactMap { try? $0.fillShapeStyle(Color.self) }
-
-        XCTAssertTrue(
-            fills.contains(AccessibilityColors.systemBackgroundSecondary),
-            "未選択カードの背景が適応色でない / observed fills: \(fills)"
-        )
-        XCTAssertFalse(
-            fills.contains(Color.gray.opacity(0.05)),
-            "ダークモードで消える gray.opacity(0.05) が残っている / observed fills: \(fills)"
-        )
-    }
 }


### PR DESCRIPTION
## 概要

Refs #151（epic は継続）

#151 は「ダークモード & Dynamic Type の一斉監査」という epic ですが、issue コメントで **「破綻修正ではなく最適化」と較正済み**で、列挙された実課題のうち **デザイン判断を伴わず客観的に直せる a11y サブセット**を先に取り込みます。残り（スプラッシュの固定ライト配色・`AccessibilityColors` の固定 hex・固定フォントサイズの Dynamic Type 追従）は epic に残します。

## 1. タップ領域（HIG 最小 44×44pt）

| 対象 | 変更前 | 変更後 |
|---|---|---|
| `RecordCalendarView` 月送り矢印 ‹ › | 44×**32** | 44×**44** |
| `HelpRecordRow` 編集/削除アイコン | **明示 frame なし**（アイコン実寸 約 16pt） | 44×44 + `contentShape(Rectangle())` |

編集/削除は 2 つが 12pt 間隔で横並びのため、実寸のままだと押し間違いが起きやすい状態でした。`frame` だけではアイコンの形が当たり判定のままなので `contentShape` と組で広げています。

### 履歴行の横幅トレードオフ（レビュー指摘で対応）

タップ領域の 44pt 化でアクション部が **約 +52pt** 広がり、`HelpRecordRow` は `Circle(44) + タスク情報 VStack + Spacer + アクション` の `HStack` なのでタスク名側が圧迫されます。タスク名は `lineLimit(1)`（`HelpHistoryView.swift:319`）なのでレイアウト破綻はせず truncate に留まりますが、長いタスク名で切れやすくなります。

各ボタンが内部に 14pt ずつ余白を持つようになったため、**ボタン間の spacing を 12 → 4pt** に詰めて横幅を一部戻しました（アイコン間の実距離は 32pt 確保）。

## 2. ダークモードで沈む極薄塗り

未選択カードの背景 `Color.gray.opacity(0.05)` → `AccessibilityColors.systemBackgroundSecondary`（`Color(.secondarySystemBackground)`）。

- `TaskCardView`（記録タブのタスク選択）
- `ChildCardView`（記録タブの子ども選択）

適応色なのでライト/ダークで明度が反転し、どちらでも地との差が残ります。どちらも `RecordView` の素の背景の上にあることを確認済みです（`RecordView.swift:168,200` の `gray.opacity(0.1)` は空状態プレースホルダで、カード背面ではありません）。

### `TutorialTaskCardView` は据え置きました（レビュー指摘で revert）

当初は同じく適応色化しましたが、このカードは **グラデ背景（`RecordTutorialView.swift:28`）+ `.ultraThinMaterial` パネル（同 :345-348）の上**に乗っています。`secondarySystemBackground` は**不透明**なので、置き換えると透過表現を潰して「マテリアルパネルの上に単色のグレーブロック」になります。

#151 本文は「グラデ背景上の白文字（Splash / Tutorial）はダークでも成立するか未検証」と明記しており、Tutorial 画面のダークモード方針は epic 側の未決事項です。**シミュレータで確認できない面に未検証の見た目変更を載せない**判断で据え置き、対応するテストも撤去しました。結果として PR #180 が揃えた TaskCardView とのパリティは一時的に崩れますが、これは「乗っている面が違う」という理由づけのある差です。

### なぜ `brandSurfaceWarm` を使わなかったか

#175 の備考に「`brandSurfaceWarm` は #151 向けの forward provisioning」とありますが、実体は `Color(hex: "#FFF4E6")` の**固定ライト色**で、ダークモードの沈み込みは解決しません。

## テスト

| テスト | RED で観測した値 |
|---|---|
| `test_monthNavButtons_meetMinimumTapTargetSize` | `frames: [(44.0, 32.0), (44.0, 32.0)]` |
| `test_editAndDeleteButtons_meetMinimumTapTargetSize` | `buttons=2` だが `frames=0`（明示 frame 不在） |
| `TaskCardViewTests.testUnselectedCardBackgroundUsesAdaptiveColor` | `observed fills: [10% gray, 5% gray, clear, clear]` |
| `ChildCardViewTests.testUnselectedCardBackgroundUsesAdaptiveColor` | `observed fills: [#FF6B6BFF, 5% gray, clear, clear]` |

**4 件すべて、対象行を変更前の状態に戻して RED を実地観測してから実装しています。** （`ChildCardViewTests` は当初 full-suite の相乗りでしか通しておらず RED 未観測だったため、レビュー指摘を受けて production の 1 行を戻す→RED 確認→復元、の手順で検証し直しました。）

- `HelpRecordRowTests` / `ChildCardViewTests` は**新規追加**（どちらも従来テストなし）
- `test_buttonsInvokeTheirOwnCallbacks` を併設し、frame 追加の過程で `onEdit`/`onDelete` が入れ替わる事故を防いでいます
- 色は hex リテラル直書きではなく**トークン定数**と比較（トークン側の変更にテストが追随する）
- unit スイート全体 **`** TEST SUCCEEDED **`**

`fixedFrame()` による frame 検証はこのリポで初出のため、CLAUDE.md の「未検証の traversal 機構に PASS が依存するテストは観測値を dump する」ルールに従い、失敗メッセージへ実測 frame を含めています。実際この dump のおかげで `HelpRecordRow` の RED を「機構が到達不可」ではなく「frame 不在」と即断できました。

## 視覚検証

`scripts/capture-asc-screenshots.sh` で撮影して目視確認し、規約どおり出力は破棄しています（本 PR には含めていません）。同スクリプトは `-only-testing:OtetsudaiCoinUITests/ASCScreenshotUITests` にスコープされているので、他 PR で追加した UITest が撮影に混入することはありません。

- **記録タブ**: 未選択の子どもカード（花子）に明確な背景と境界が出ました。変更前は白地にほぼ溶けていたので、**ライトモードでも視認性が向上**しています。選択中（太郎）のオレンジ表現は維持
- **月送り矢印**: 正常描画、クリップなし。高さ +12pt ぶんカレンダーヘッダーが伸びますが、記録タブは ScrollView なのでレイアウト破綻はありません

**未確認**: 履歴画面は ASC スクショの対象外（タブは ホーム/記録/設定 の 3 つで、履歴はホームから子どもを選んだ先）のため、`HelpRecordRow` の実レンダリングは目視していません。判断はコード読み（`lineLimit(1)` による graceful truncation）と unit test に基づいています。

## スコープ外（記録のみ、本 PR では直しません）

- `TaskCardView.swift:61` のアイコン円 `Color.gray.opacity(0.1)` も同様にライト前提ですが、#151 が名指ししているのは `opacity(0.05)` の極薄塗りなので今回は触っていません
- `HelpHistoryView.swift:367` の `formatter.locale = Locale(identifier: "ja_JP")` ハードコード（en ロケールでも日本語書式になる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWykbCsx2qEb7hfBmRW1pi