### PR TITLE
fix(#175): チュートリアル CTA を SolidButtonStyle に統一 (Finding 3)

### DIFF
--- a/app/OtetsudaiCoin/Presentation/Views/Tutorial/ChildTutorialView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/Tutorial/ChildTutorialView.swift
@@ -161,19 +161,8 @@ struct ChildTutorialView: View {
                         Image(systemName: "plus.circle.fill")
                         Text("お子様を追加")
                     }
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 32)
-                    .padding(.vertical, 16)
-                    .background(
-                        AccessibilityColors.brandPrimary
-                    )
-                    .clipShape(Capsule())
-                    .shadow(radius: 8)
                 }
-                .scaleEffect(hasAddedChild ? 0.8 : 1.0)
-                .opacity(hasAddedChild ? 0.5 : 1.0)
+                .primaryButton(isDisabled: hasAddedChild)
                 .disabled(hasAddedChild)
             }
         }


### PR DESCRIPTION
## 概要

Issue #175 Finding 3 の対応。`ChildTutorialView` の「お子様を追加」CTA が app 内で唯一の Capsule 型 + raw `shadow(radius: 8)` のまま残っていたため、#147 で確立した `SolidButtonStyle` (`.primaryButton()`) へ統一しました。

## 変更内容

- 手組みスタイル (title2 フォント / 独自 padding / brandPrimary background / `clipShape(Capsule())` / raw shadow) を削除し `.primaryButton(isDisabled: hasAddedChild)` + `.disabled(hasAddedChild)` に置換(既存 caller の convention に一致)
- `hasAddedChild` 依存の `scaleEffect`/`opacity` は、この分岐 (`else` = 未登録時のみ描画) では常に無効果の dead modifier だったため除去

## テスト・検証

- unit テスト全体 (`OtetsudaiCoinTests`): `** TEST SUCCEEDED **`(初回 run で 1 件 fail したが再実行 2 回連続 green = 既知の並列 simulator flake と判断)
- 視覚検証: 一時 UITest(working tree のみ、commit せず破棄)で tutorial step 2 を before/after 撮影し目視比較。Capsule → ソフト角丸 / shadow が `AppShadow.cardElevated` 相当に変化、ブランドオレンジ維持を確認済み

## Plan からの逸脱 / 補足

- 新規 unit テストなし: style 適用の wiring は #147 の前例通り視覚検証で担保(ChildTutorialView は `.ultraThinMaterial` + sheet 構成で ViewInspector 制約領域)。TDD red 省略はこの理由による
- 視覚検証中の out-of-scope 所見: step 2 の `person.circle.fill` / FeatureRow / TutorialStep の `.blue` は **#175 Finding 2 で起票済み**(#151/#155 合流予定)のため本 PR では触らない

Closes しない (epic 継続): #175 は Finding 4 対応後もコメントで進捗管理

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113ediP1yodkqxsLF4gbMhq