### PR TITLE
refactor(#175): SolidButtonStyle の isDisabled 二重配線を isEnabled 環境値駆動に統一 (Finding 4)

### DIFF
--- a/app/OtetsudaiCoin/Presentation/Components/RecordButtonBar.swift
+++ b/app/OtetsudaiCoin/Presentation/Components/RecordButtonBar.swift
@@ -22,7 +22,7 @@ struct RecordButtonBar: View {
                     Text(recordButtonLabel)
                 }
             }
-            .successButton(isDisabled: recordButtonDisabled)
+            .successButton()
             .disabled(recordButtonDisabled)
             .accessibilityIdentifier("record_button")
         }

--- a/app/OtetsudaiCoin/Presentation/Views/ChildFormView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/ChildFormView.swift
@@ -105,7 +105,7 @@ struct ChildFormView: View {
                             Text(isEditing ? "更新" : "追加")
                         }
                     }
-                    .primaryButton(isDisabled: !isValidInput)
+                    .primaryButton()
                     .disabled(!isValidInput)
                     .accessibilityIdentifier("main_save_button")
                 }

--- a/app/OtetsudaiCoin/Presentation/Views/Components/AppButtonStyle.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/Components/AppButtonStyle.swift
@@ -4,13 +4,14 @@ import SwiftUI
 
 /// ブランドカラー単色 + ソフト角丸 (AppRadius.xLarge) のボタンスタイル。
 /// 旧グラデーションボタンスタイルの後継。押下時の縮小アニメーションは踏襲し、グローは廃止。
+/// 無効状態は `.disabled(_:)` からの `\.isEnabled` 環境値で自動追随する (#175 Finding 4)。
 struct SolidButtonStyle: ButtonStyle {
     let backgroundColor: Color
-    let isDisabled: Bool
 
-    init(backgroundColor: Color = AccessibilityColors.brandPrimary, isDisabled: Bool = false) {
+    @Environment(\.isEnabled) private var isEnabled
+
+    init(backgroundColor: Color = AccessibilityColors.brandPrimary) {
         self.backgroundColor = backgroundColor
-        self.isDisabled = isDisabled
     }
 
     func makeBody(configuration: Configuration) -> some View {
@@ -20,12 +21,28 @@ struct SolidButtonStyle: ButtonStyle {
             .foregroundColor(.white)
             .padding(.horizontal, 32)
             .padding(.vertical, 16)
-            .background(isDisabled ? Color.gray.opacity(0.6) : backgroundColor)
+            .background(Self.background(for: backgroundColor, isEnabled: isEnabled))
             .clipShape(RoundedRectangle(cornerRadius: AppRadius.xLarge))
-            .appShadow(isDisabled ? AppShadowStyle(color: .clear, radius: 0, x: 0, y: 0) : AppShadow.cardElevated)
+            .appShadow(Self.shadow(isEnabled: isEnabled))
             .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
-            .opacity(isDisabled ? 0.6 : 1.0)
+            .opacity(Self.opacity(isEnabled: isEnabled))
             .animation(.easeInOut(duration: 0.2), value: configuration.isPressed)
+    }
+}
+
+// MARK: - 有効/無効の見た目マッピング (pure helper — unit test 対象)
+
+extension SolidButtonStyle {
+    static func background(for backgroundColor: Color, isEnabled: Bool) -> Color {
+        isEnabled ? backgroundColor : Color.gray.opacity(0.6)
+    }
+
+    static func opacity(isEnabled: Bool) -> Double {
+        isEnabled ? 1.0 : 0.6
+    }
+
+    static func shadow(isEnabled: Bool) -> AppShadowStyle {
+        isEnabled ? AppShadow.cardElevated : AppShadow.none
     }
 }
 
@@ -43,15 +60,15 @@ extension SolidButtonStyle {
 // MARK: - View Extension
 
 extension View {
-    func primaryButton(isDisabled: Bool = false) -> some View {
-        buttonStyle(SolidButtonStyle(backgroundColor: AccessibilityColors.brandPrimary, isDisabled: isDisabled))
+    func primaryButton() -> some View {
+        buttonStyle(SolidButtonStyle(backgroundColor: AccessibilityColors.brandPrimary))
     }
 
-    func successButton(isDisabled: Bool = false) -> some View {
-        buttonStyle(SolidButtonStyle(backgroundColor: AccessibilityColors.brandSecondary, isDisabled: isDisabled))
+    func successButton() -> some View {
+        buttonStyle(SolidButtonStyle(backgroundColor: AccessibilityColors.brandSecondary))
     }
 
-    func destructiveButton(isDisabled: Bool = false) -> some View {
-        buttonStyle(SolidButtonStyle(backgroundColor: AccessibilityColors.errorRed, isDisabled: isDisabled))
+    func destructiveButton() -> some View {
+        buttonStyle(SolidButtonStyle(backgroundColor: AccessibilityColors.errorRed))
     }
 }

--- a/app/OtetsudaiCoin/Presentation/Views/HelpRecordEditView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HelpRecordEditView.swift
@@ -130,7 +130,7 @@ struct HelpRecordEditView: View {
                     Text("変更を保存")
                 }
             }
-            .primaryButton(isDisabled: !viewModel.hasChanges || viewModel.isLoading)
+            .primaryButton()
             .disabled(!viewModel.hasChanges || viewModel.isLoading)
             
             // 削除ボタン
@@ -142,7 +142,7 @@ struct HelpRecordEditView: View {
                     Text("記録を削除")
                 }
             }
-            .destructiveButton(isDisabled: viewModel.isLoading)
+            .destructiveButton()
             .disabled(viewModel.isLoading)
         }
     }

--- a/app/OtetsudaiCoin/Presentation/Views/TaskManagementView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/TaskManagementView.swift
@@ -229,7 +229,7 @@ struct TaskFormView: View {
                     }) {
                         Text(isEditing ? "更新" : "追加")
                     }
-                    .successButton(isDisabled: taskName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .successButton()
                     .disabled(taskName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }

--- a/app/OtetsudaiCoin/Presentation/Views/Tutorial/ChildTutorialView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/Tutorial/ChildTutorialView.swift
@@ -162,7 +162,7 @@ struct ChildTutorialView: View {
                         Text("お子様を追加")
                     }
                 }
-                .primaryButton(isDisabled: hasAddedChild)
+                .primaryButton()
                 .disabled(hasAddedChild)
             }
         }

--- a/app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift
@@ -321,7 +321,7 @@ struct RecordTutorialView: View {
                                 Text("記録する")
                             }
                         }
-                        .successButton(isDisabled: hasRecorded)
+                        .successButton()
                         .disabled(hasRecorded)
                         
                         if hasRecorded {

--- a/app/OtetsudaiCoin/Utils/DesignTokens.swift
+++ b/app/OtetsudaiCoin/Utils/DesignTokens.swift
@@ -75,6 +75,8 @@ enum AppShadow {
     static let cardElevated = AppShadowStyle(color: .black.opacity(0.08), radius: 4, x: 0, y: 2)
     /// 強い影（フローティング要素・ヒーローカード）: 黒10% / radius 10 / y5
     static let floating = AppShadowStyle(color: .black.opacity(0.1), radius: 10, x: 0, y: 5)
+    /// 影なし（無効状態のボタン等）
+    static let none = AppShadowStyle(color: .clear, radius: 0, x: 0, y: 0)
 }
 
 // MARK: - SwiftUI View Extensions

--- a/app/OtetsudaiCoinTests/Presentation/Components/AppButtonStyleTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/AppButtonStyleTests.swift
@@ -4,9 +4,10 @@ import SwiftUI
 
 final class AppButtonStyleTests: XCTestCase {
 
+    // MARK: - プリセット
+
     func testPrimaryPresetUsesBrandPrimary() {
         XCTAssertEqual(SolidButtonStyle.primary.backgroundColor, AccessibilityColors.brandPrimary)
-        XCTAssertFalse(SolidButtonStyle.primary.isDisabled)
     }
 
     func testSuccessPresetUsesBrandSecondary() {
@@ -17,14 +18,43 @@ final class AppButtonStyleTests: XCTestCase {
         XCTAssertEqual(SolidButtonStyle.destructive.backgroundColor, AccessibilityColors.errorRed)
     }
 
-    func testDefaultInitIsPrimaryEnabled() {
+    func testDefaultInitIsPrimary() {
         let style = SolidButtonStyle()
         XCTAssertEqual(style.backgroundColor, AccessibilityColors.brandPrimary)
-        XCTAssertFalse(style.isDisabled)
     }
 
-    func testDisabledFlagIsStored() {
-        let style = SolidButtonStyle(backgroundColor: AccessibilityColors.brandPrimary, isDisabled: true)
-        XCTAssertTrue(style.isDisabled)
+    // MARK: - 有効/無効の見た目マッピング (#175 Finding 4)
+    // isDisabled stored flag を廃止し @Environment(\.isEnabled) 駆動に変えたため、
+    // 環境値 → 見た目の対応は pure helper で担保する (environment 注入は
+    // ViewInspector でテスト不可のため、#125 の pure 関数抽出パターンを踏襲)。
+
+    func testBackgroundKeepsColorWhenEnabled() {
+        XCTAssertEqual(
+            SolidButtonStyle.background(for: AccessibilityColors.brandSecondary, isEnabled: true),
+            AccessibilityColors.brandSecondary
+        )
+    }
+
+    func testBackgroundTurnsGrayWhenDisabled() {
+        XCTAssertEqual(
+            SolidButtonStyle.background(for: AccessibilityColors.brandPrimary, isEnabled: false),
+            Color.gray.opacity(0.6)
+        )
+    }
+
+    func testOpacityMapping() {
+        XCTAssertEqual(SolidButtonStyle.opacity(isEnabled: true), 1.0)
+        XCTAssertEqual(SolidButtonStyle.opacity(isEnabled: false), 0.6)
+    }
+
+    func testShadowMapping() {
+        XCTAssertEqual(SolidButtonStyle.shadow(isEnabled: true), AppShadow.cardElevated)
+        XCTAssertEqual(SolidButtonStyle.shadow(isEnabled: false), AppShadow.none)
+    }
+
+    // MARK: - AppShadow.none プリセット (#175 Finding 4)
+
+    func testAppShadowNoneIsInvisible() {
+        XCTAssertEqual(AppShadow.none, AppShadowStyle(color: .clear, radius: 0, x: 0, y: 0))
     }
 }


### PR DESCRIPTION
## 概要

Issue #175 Finding 4 の対応。全 caller が `.xxxButton(isDisabled: X)` と `.disabled(X)` を二重に渡していた boilerplate を解消し、`SolidButtonStyle` が `.disabled(_:)` からの `@Environment(\.isEnabled)` を読んで無効時の見た目を自動追随する形にリファクタしました。

## 変更内容

- `SolidButtonStyle`: stored `isDisabled` flag を廃止し `@Environment(\.isEnabled)` を読む形へ。無効時の見た目 (gray 背景 / opacity 0.6 / 影なし) は不変
- 見た目マッピングを pure static helper (`background(for:isEnabled:)` / `opacity(isEnabled:)` / `shadow(isEnabled:)`) に抽出 (#125 の pure 関数抽出パターン。environment 注入は ViewInspector でテスト不可のため)
- `AppShadow.none` プリセット新設 (インライン `AppShadowStyle(color: .clear, ...)` を置換)
- caller 7 箇所 (RecordButtonBar / HelpRecordEditView ×2 / ChildFormView / RecordTutorialView / TaskManagementView / ChildTutorialView) の `isDisabled:` 引数を削除し `.disabled()` のみに

## 安全性の検証

- **caller 全 grep で二重配線を事前確認**: 7 箇所すべてが同一条件で `.disabled()` を併用しており、引数削除で「見た目だけ無効・実際は押せる」regression が起きないことを確証してから着手 (CLAUDE.md ルール準拠)
- 削除 API の残存参照を app / Tests / UITests の 3 ターゲット grep で 0 件確認

## テスト・検証

- TDD: pure helper のテスト (enabled/disabled × background/opacity/shadow + `AppShadow.none`) を先に作成 (red はコンパイルエラー確定のため実行 skip、下記逸脱参照) → 実装後 `AppButtonStyleTests` 9 件を含む unit 全体で `** TEST SUCCEEDED **`
- 視覚検証: 一時 UITest (commit せず破棄) で ChildFormView の無効状態「追加」ボタンを before/after 撮影。**ピクセル同等** (差分は status bar 時刻のみ) を目視確認済み — `.disabled()` → environment 伝播が旧 stored flag と同じ見た目を再現

## Plan からの逸脱

- TDD red の実行 skip: 新規 helper メソッド未定義による `BUILD FAILED` 確定ケースのため (CLAUDE.md の skip 許容条件 (a))
- 旧 `testDisabledFlagIsStored` 等の stored property テストは API 廃止に伴い削除し、pure helper テストで置換

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113ediP1yodkqxsLF4gbMhq