### PR TITLE
fix(#155): 月まとめ・履歴画面の i18n 漏れ (月ラベル・日付グループ・時刻の ja_JP 固定) を locale 対応へ

### DIFF
--- a/app/OtetsudaiCoin/Presentation/ViewModels/MonthlySummaryViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/MonthlySummaryViewModel.swift
@@ -164,7 +164,7 @@ class MonthlySummaryViewModel {
                 expected: totalCoins
             )
 
-            let monthLabel = "\(year)年\(month)月"
+            let monthLabel = Self.monthLabel(year: year, month: month, locale: Locale.current)
 
             self.snapshot = MonthSnapshot(
                 monthLabel: monthLabel,
@@ -184,6 +184,27 @@ class MonthlySummaryViewModel {
             DebugLogger.error("loadMonth failed: \(error)")
             self.snapshot = nil
         }
+    }
+
+    /// 表示用の月ラベルを locale に応じて生成する (#155 コメント報告の i18n 漏れ対応)。
+    ///
+    /// 旧実装は "\(year)年\(month)月" の日本語ハードコードで、en ロケールでも
+    /// 日本語表記が出ていた。`yMMMM` テンプレートは ja で「2026年7月」(現行と同一)、
+    /// en で「July 2026」になる。テスト可能にするため locale を引数に取る static helper とする。
+    nonisolated static func monthLabel(year: Int, month: Int, locale: Locale) -> String {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = 1
+        let calendar = Calendar(identifier: .gregorian)
+        guard let date = calendar.date(from: components) else {
+            return "\(year)/\(month)"
+        }
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("yMMMM")
+        return formatter.string(from: date)
     }
 
     private func computeTaskBreakdown(records: [HelpRecord], taskMap: [UUID: HelpTask]) -> [MonthSnapshot.TaskBreakdownItem] {

--- a/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
@@ -221,25 +221,47 @@ struct HelpHistoryView: View {
     }
     
     private var groupedRecords: [(key: String, value: [HelpRecordWithDetails])] {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "M月d日 (E)"
-        formatter.locale = Locale(identifier: "ja_JP")
-        
+        let locale = Locale.current
+
         let grouped = Dictionary(grouping: viewModel.helpRecords) { record in
-            formatter.string(from: record.helpRecord.recordedAt)
+            Self.dayGroupLabel(from: record.helpRecord.recordedAt, locale: locale)
         }
-        
+
         return grouped.sorted { lhs, rhs in
             let lhsDate = viewModel.helpRecords.first { record in
-                formatter.string(from: record.helpRecord.recordedAt) == lhs.key
+                Self.dayGroupLabel(from: record.helpRecord.recordedAt, locale: locale) == lhs.key
             }?.helpRecord.recordedAt ?? Date.distantPast
-            
+
             let rhsDate = viewModel.helpRecords.first { record in
-                formatter.string(from: record.helpRecord.recordedAt) == rhs.key
+                Self.dayGroupLabel(from: record.helpRecord.recordedAt, locale: locale) == rhs.key
             }?.helpRecord.recordedAt ?? Date.distantPast
-            
+
             return lhsDate > rhsDate
         }
+    }
+
+    /// 履歴の日付グループ見出しを locale に応じて生成する (#155 コメント報告の i18n 漏れ対応)。
+    ///
+    /// 旧実装は `dateFormat = "M月d日 (E)"` + ja_JP 固定で、en ロケールでも日本語表記が出ていた。
+    /// `MMMEd` テンプレートは ja で「7月15日(水)」(現行「7月15日 (水)」とほぼ同一、括弧前スペースのみ差)、
+    /// en で「Wed, Jul 15」になる。テスト可能にするため locale を引数に取る static helper とする。
+    static func dayGroupLabel(from date: Date, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("MMMEd")
+        return formatter.string(from: date)
+    }
+
+    /// 記録時刻を locale に応じて生成する (#155 コメント報告の i18n 漏れ対応)。
+    ///
+    /// 旧実装は `HelpRecordRow` 内の private func で ja_JP 固定になっており、
+    /// en ロケールでも 24 時間表記が強制されていた。`.short` スタイルは
+    /// ja で「9:05」(現行と同一)、en で「9:05 AM」になる。
+    static func timeString(from date: Date, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.locale = locale
+        return formatter.string(from: date)
     }
     
     private func createEditView(for record: HelpRecordWithDetails) -> some View {
@@ -319,7 +341,7 @@ struct HelpRecordRow: View {
                     .lineLimit(1)
                 
                 HStack(spacing: 8) {
-                    Text(timeString(from: record.helpRecord.recordedAt))
+                    Text(HelpHistoryView.timeString(from: record.helpRecord.recordedAt, locale: Locale.current))
                         .font(.caption)
                         .foregroundColor(.secondary)
                     
@@ -371,12 +393,6 @@ struct HelpRecordRow: View {
         .padding(.vertical, 8)
     }
     
-    private func timeString(from date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.timeStyle = .short
-        formatter.locale = Locale(identifier: "ja_JP")
-        return formatter.string(from: date)
-    }
 }
 
 

--- a/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
@@ -221,35 +221,43 @@ struct HelpHistoryView: View {
     }
     
     private var groupedRecords: [(key: String, value: [HelpRecordWithDetails])] {
-        let locale = Locale.current
+        // formatter 生成 (ICU 初期化) は安くないため、旧実装同様に 1 インスタンスを
+        // grouping / sort lookup で使い回す (sort lookup は O(n²) 回呼ばれる)。
+        let formatter = Self.makeDayGroupFormatter(locale: Locale.current)
 
         let grouped = Dictionary(grouping: viewModel.helpRecords) { record in
-            Self.dayGroupLabel(from: record.helpRecord.recordedAt, locale: locale)
+            formatter.string(from: record.helpRecord.recordedAt)
         }
 
         return grouped.sorted { lhs, rhs in
             let lhsDate = viewModel.helpRecords.first { record in
-                Self.dayGroupLabel(from: record.helpRecord.recordedAt, locale: locale) == lhs.key
+                formatter.string(from: record.helpRecord.recordedAt) == lhs.key
             }?.helpRecord.recordedAt ?? Date.distantPast
 
             let rhsDate = viewModel.helpRecords.first { record in
-                Self.dayGroupLabel(from: record.helpRecord.recordedAt, locale: locale) == rhs.key
+                formatter.string(from: record.helpRecord.recordedAt) == rhs.key
             }?.helpRecord.recordedAt ?? Date.distantPast
 
             return lhsDate > rhsDate
         }
     }
 
-    /// 履歴の日付グループ見出しを locale に応じて生成する (#155 コメント報告の i18n 漏れ対応)。
+    /// 履歴の日付グループ見出し用の locale 対応 formatter を生成する (#155 コメント報告の i18n 漏れ対応)。
     ///
     /// 旧実装は `dateFormat = "M月d日 (E)"` + ja_JP 固定で、en ロケールでも日本語表記が出ていた。
     /// `MMMEd` テンプレートは ja で「7月15日(水)」(現行「7月15日 (水)」とほぼ同一、括弧前スペースのみ差)、
-    /// en で「Wed, Jul 15」になる。テスト可能にするため locale を引数に取る static helper とする。
-    static func dayGroupLabel(from date: Date, locale: Locale) -> String {
+    /// en で「Wed, Jul 15」になる。
+    static func makeDayGroupFormatter(locale: Locale) -> DateFormatter {
         let formatter = DateFormatter()
         formatter.locale = locale
         formatter.setLocalizedDateFormatFromTemplate("MMMEd")
-        return formatter.string(from: date)
+        return formatter
+    }
+
+    /// `makeDayGroupFormatter` の薄い wrapper。単発フォーマット / テスト用。
+    /// `groupedRecords` のようなループ内では formatter を 1 度だけ作って使い回すこと。
+    static func dayGroupLabel(from date: Date, locale: Locale) -> String {
+        makeDayGroupFormatter(locale: locale).string(from: date)
     }
 
     /// 記録時刻を locale に応じて生成する (#155 コメント報告の i18n 漏れ対応)。

--- a/app/OtetsudaiCoinTests/Presentation/MonthlySummaryViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/MonthlySummaryViewModelTests.swift
@@ -143,8 +143,12 @@ final class MonthlySummaryViewModelTests: XCTestCase {
         XCTAssertEqual(snap.taskBreakdown.first?.count, 2)
         XCTAssertEqual(snap.highlights.consecutiveDayStreak, 1)
         XCTAssertEqual(snap.paymentStatus, .unpaid)
-        XCTAssertTrue(snap.monthLabel.contains("\(thisMonth.year!)"))
-        XCTAssertTrue(snap.monthLabel.contains("\(thisMonth.month!)"))
+        // monthLabel は locale 依存 (en: "August 2026" は数字の月を含まない) ため、
+        // 数字 contains ではなく helper と同一出力であることを assert する。
+        let expectedLabel = MonthlySummaryViewModel.monthLabel(
+            year: thisMonth.year!, month: thisMonth.month!, locale: Locale.current
+        )
+        XCTAssertEqual(snap.monthLabel, expectedLabel, "rendered: \(snap.monthLabel)")
     }
 
     @MainActor
@@ -359,5 +363,24 @@ final class MonthlySummaryViewModelTests: XCTestCase {
         await viewModel.loadMonth()
 
         XCTAssertNil(viewModel.snapshot, "失敗時に前回の snapshot が残ると月と数字が食い違う")
+    }
+
+    // MARK: - 月ラベルの i18n (#155 コメント報告分)
+
+    /// ja では現行表記「2026年7月」と同一であること (非退行)。
+    func testMonthLabelJapaneseLocaleKeepsCurrentStyle() {
+        let label = MonthlySummaryViewModel.monthLabel(
+            year: 2026, month: 7, locale: Locale(identifier: "ja_JP")
+        )
+        XCTAssertEqual(label, "2026年7月", "rendered: \(label)")
+    }
+
+    /// en では日本語ハードコードではなく「July 2026」相当になること。
+    func testMonthLabelEnglishLocaleUsesLocalizedTemplate() {
+        let label = MonthlySummaryViewModel.monthLabel(
+            year: 2026, month: 7, locale: Locale(identifier: "en_US")
+        )
+        XCTAssertEqual(label, "July 2026", "rendered: \(label)")
+        XCTAssertFalse(label.contains("年"), "en locale に日本語表記が混入: \(label)")
     }
 }

--- a/app/OtetsudaiCoinTests/Presentation/Views/HelpHistoryViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Views/HelpHistoryViewTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import OtetsudaiCoin
+
+/// HelpHistoryView の日付・時刻フォーマット helper のテスト (#155 コメント報告の i18n 漏れ)。
+///
+/// - 日付 fixture は固定絶対日付 (2026-07-15 = 月中日) を使い、実行日非依存にする (#112/#114/#115 の flake 対策)。
+/// - locale は明示的に ja_JP / en_US を渡し、実行環境 locale に依存しない。
+/// - View 本体の traverse は ViewInspector の既知制約があるため行わず、static helper を直接検証する。
+final class HelpHistoryViewTests: XCTestCase {
+
+    /// 2026-07-15 (水) 09:05 を gregorian で固定生成する。
+    private func fixedDate(hour: Int = 9, minute: Int = 5) -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 7
+        components.day = 15
+        components.hour = hour
+        components.minute = minute
+        let calendar = Calendar(identifier: .gregorian)
+        return calendar.date(from: components)!
+    }
+
+    // MARK: - dayGroupLabel (履歴の日付グループ見出し)
+
+    /// ja では現行の「7月15日 (水)」とほぼ同等 (テンプレート化で括弧前スペースのみ消える) であること (非退行)。
+    func testDayGroupLabelJapaneseLocaleKeepsCurrentStyle() {
+        let label = HelpHistoryView.dayGroupLabel(
+            from: fixedDate(), locale: Locale(identifier: "ja_JP")
+        )
+        XCTAssertEqual(label, "7月15日(水)", "rendered: \(label)")
+    }
+
+    /// en では「Wed, Jul 15」相当のローカライズ表記になること (旧実装は ja_JP 固定で「7月15日 (水)」が出る実バグ)。
+    func testDayGroupLabelEnglishLocaleUsesLocalizedTemplate() {
+        let label = HelpHistoryView.dayGroupLabel(
+            from: fixedDate(), locale: Locale(identifier: "en_US")
+        )
+        XCTAssertEqual(label, "Wed, Jul 15", "rendered: \(label)")
+        XCTAssertFalse(label.contains("月"), "en locale に日本語表記が混入: \(label)")
+    }
+
+    // MARK: - timeString (記録時刻)
+
+    /// ja では現行の「9:05」と同一であること (非退行)。
+    func testTimeStringJapaneseLocaleKeepsCurrentStyle() {
+        let time = HelpHistoryView.timeString(
+            from: fixedDate(), locale: Locale(identifier: "ja_JP")
+        )
+        XCTAssertEqual(time, "9:05", "rendered: \(time)")
+    }
+
+    /// en では 12 時間表記 + AM/PM になること。
+    /// AM 前の空白は ICU バージョンにより U+202F (narrow no-break space) になるため、
+    /// 空白文字そのものは assert せず prefix + AM 含有で判定する。
+    func testTimeStringEnglishLocaleUsesLocalizedStyle() {
+        let time = HelpHistoryView.timeString(
+            from: fixedDate(), locale: Locale(identifier: "en_US")
+        )
+        XCTAssertTrue(time.hasPrefix("9:05"), "rendered: \(time)")
+        XCTAssertTrue(time.contains("AM"), "rendered: \(time)")
+    }
+}


### PR DESCRIPTION
## 概要

Refs #155

Issue #155 のコメント (2026-07-28) で報告された **UI 層の i18n 漏れ 3 箇所のみ**を修正します (en ロケールでも日本語の日付・時刻表記が出る実バグ)。#155 本体のデザイン課題 (¥/コイン統一・KPI カード・グラフ刷新) はスコープ外です。

## 修正内容 (before/after)

各箇所を **locale をパラメータに取る static helper** に抽出し、View/ViewModel からは `Locale.current` で呼びます (helper が unit-testable になる)。xcstrings の変更はありません (`setLocalizedDateFormatFromTemplate` の locale 対応テンプレートで解決)。

| 箇所 | 旧実装 | ja before | ja after | en before (バグ) | en after |
|---|---|---|---|---|---|
| 月ラベル (`MonthlySummaryViewModel`) | `"\(year)年\(month)月"` ハードコード | `2026年7月` | `2026年7月` (同一) | `2026年7月` | `July 2026` |
| 履歴の日付グループ見出し (`HelpHistoryView.groupedRecords`) | `dateFormat = "M月d日 (E)"` + `ja_JP` 固定 | `7月15日 (水)` | `7月15日(水)` (括弧前スペースのみ差) | `7月15日 (水)` | `Wed, Jul 15` |
| 記録時刻 (`HelpRecordRow`) | `timeStyle = .short` + `ja_JP` 固定 | `9:05` | `9:05` (同一) | `9:05` (24h 強制) | `9:05 AM` |

- 月ラベルは `yMMMM`、日付グループは `MMMEd` テンプレート。**ja の出力はテスト実行結果で非退行を確認済み** (記憶ではなく simulator 上の assert で確認)。
- `groupedRecords` の grouping/sort 構造は不変 (フォーマッタ構築のみ helper へ移動)。

## テスト (TDD)

新規 6 件 + 既存 1 件更新。日付 fixture は固定絶対日付 (2026-07-15、月中日) + 明示的な `Locale(identifier:)` で実行日・実行環境 locale 非依存 (#112/#114/#115 の flake 対策)。assert には観測値 dump の failure message 付き。

- `MonthlySummaryViewModelTests`: `testMonthLabelJapaneseLocaleKeepsCurrentStyle` / `testMonthLabelEnglishLocaleUsesLocalizedTemplate`
- `HelpHistoryViewTests` (新規ファイル): `dayGroupLabel` ja/en、`timeString` ja/en の 4 件
- en 時刻の AM 前空白は ICU バージョンにより U+202F (narrow no-break space) になるため、空白文字は assert せず `hasPrefix("9:05")` + `contains("AM")` で判定

結果: `-only-testing:OtetsudaiCoinTests` 全体で `** TEST SUCCEEDED **` (iPhone 17 simulator, iOS 26.5)。新規 6 テストすべて passed をログで確認済み。

## Plan からの逸脱

1. **RED 実行 skip**: helper 未定義によるコンパイルエラー確定のため、repo ルールの skip 条件 (a) を適用 (commit message にも明記)。
2. **simulator destination**: 指定の `iPhone 16` は本環境に存在しないため `iPhone 17` (iOS 26.5) で代替。
3. **`timeString` の所属**: 指示の行参照は `HelpHistoryView.swift:374-379` だったが、実際の所有者はファイル内の別 struct `HelpRecordRow` (private func)。helper は `dayGroupLabel` と同居させるため `HelpHistoryView` の static へ移し、`HelpRecordRow` から `HelpHistoryView.timeString(...)` を呼ぶ形にした。
4. **既存 assert の更新**: `testLoadMonthComputesSnapshot...` の `monthLabel.contains("\(month)")` は locale 依存になる (en では "August 2026" が数字の月を含まない) ため、helper との同一出力 assert へ更新。
5. **`nonisolated` 付与**: `MonthlySummaryViewModel` が `@MainActor` のため static helper が isolation を継承しコンパイルエラーになった。pure 関数なので `nonisolated` を付与。
6. **UITests は未実行** (`-only-testing:OtetsudaiCoinTests` 指定通り)。削除した private func / 旧フォーマット文字列への参照が app / Tests / UITests の全ターゲットに無いことは grep で確認済み。

## レビュー対応 (code-quality finding)

- **`groupedRecords` の DateFormatter O(n²) 生成 perf regression を修正** (commit 265fbad): 初版では `dayGroupLabel(from:locale:)` が呼び出しごとに `DateFormatter` (ICU 初期化) を新規生成しており、sort lookup の O(n²) 呼び出しで main thread に乗るコストが増えていた。`makeDayGroupFormatter(locale:)` を追加し、`groupedRecords` は旧実装同様の 1 インスタンス使い回しへ復帰。`dayGroupLabel` は薄い wrapper 化。出力は同一のため既存テストは期待値変更なしで green (`** TEST SUCCEEDED **` 再確認済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

