### PR TITLE
feat(#149): 子ども0人時の Home 空状態に「新しい子供を追加」CTA を追加

### DIFF
--- a/app/OtetsudaiCoin/ContentView.swift
+++ b/app/OtetsudaiCoin/ContentView.swift
@@ -72,7 +72,7 @@ struct ContentView: View {
     
     private var mainAppView: some View {
         TabView(selection: $selectedTab) {
-            HomeView(viewModel: homeViewModel)
+            HomeView(viewModel: homeViewModel, childManagementViewModel: childManagementViewModel)
                 .tabItem {
                     Image(systemName: "house.fill")
                     Text("ホーム")

--- a/app/OtetsudaiCoin/Presentation/Views/HomeView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HomeView.swift
@@ -5,6 +5,7 @@ struct HomeView: View {
     @Bindable var viewModel: HomeViewModel
     // 子ども 0 人時の空状態 CTA から ChildFormView を開くための pass-through (Issue #149)
     let childManagementViewModel: ChildManagementViewModel
+    @State private var showingAddChildForm = false
 
     var body: some View {
         NavigationStack {
@@ -36,6 +37,18 @@ struct HomeView: View {
                             .appFont(.sectionHeader)
                             .foregroundColor(AccessibilityColors.textSecondary)
                             .padding()
+                        // Issue #149: 空状態から直接子ども登録へ進める CTA
+                        // (履歴画面の空状態 CTA と同じ .primaryButton() パターン)
+                        Button(action: {
+                            showingAddChildForm = true
+                        }) {
+                            HStack {
+                                Image(systemName: "plus.circle.fill")
+                                Text("新しい子供を追加")
+                            }
+                        }
+                        .primaryButton()
+                        .accessibilityIdentifier("home_empty_add_child_button")
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
@@ -64,6 +77,10 @@ struct HomeView: View {
                 // 自動再ロードと競合してメイン画面が空表示のまま固定されるケースが残っていた。
                 await viewModel.loadChildrenAsync()
             }
+        }
+        .sheet(isPresented: $showingAddChildForm) {
+            // SettingsView の追加フローと同じ形 (ChildFormView + editingChild: nil)
+            ChildFormView(viewModel: childManagementViewModel, editingChild: nil)
         }
         .alert("エラー", isPresented: .constant(viewModel.errorMessage != nil)) {
             Button("OK") {

--- a/app/OtetsudaiCoin/Presentation/Views/HomeView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HomeView.swift
@@ -3,6 +3,8 @@ import UIKit
 
 struct HomeView: View {
     @Bindable var viewModel: HomeViewModel
+    // 子ども 0 人時の空状態 CTA から ChildFormView を開くための pass-through (Issue #149)
+    let childManagementViewModel: ChildManagementViewModel
 
     var body: some View {
         NavigationStack {

--- a/app/OtetsudaiCoinTests/Presentation/Views/HomeViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Views/HomeViewTests.swift
@@ -120,6 +120,38 @@ final class HomeViewTests: XCTestCase {
         
         XCTAssertNoThrow(try view.inspect().find(text: "お子様を登録してください", locale: Locale(identifier: "ja")))
     }
+
+    @MainActor
+    func testHomeViewEmptyStateShowsAddChildCTA() throws {
+        // Issue #149: 子ども 0 人時の空状態に「新しい子供を追加」CTA を表示する。
+        // 空状態には Image(systemName:)+.foregroundColor (AccessibilityImageLabel blocker)
+        // があるため、find(viewWithAccessibilityIdentifier:) ではなく findAll ベースで検証する
+        // (iOS 26 + ViewInspector 0.10.2 の既知制約)。
+        viewModel.children = []
+
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
+
+        // CTA ラベル Text が描画されること (findAll は blocker を跨いで Text を列挙できる)。
+        // test host は en locale で走るため、既存テストの find(text:locale:) と同様に
+        // string(locale: ja) でローカライズキーを ja 解決して比較する。
+        let ja = Locale(identifier: "ja")
+        let texts = try view.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string(locale: ja) }
+        XCTAssertTrue(
+            texts.contains("新しい子供を追加"),
+            "空状態に CTA ラベルが見つからない。rendered texts: \(texts)"
+        )
+
+        // CTA が Button として存在すること (label 内 Text でフィルタ)
+        let buttons = try view.inspect().findAll(ViewType.Button.self)
+        let ctaButtons = buttons.filter { button in
+            let labelTexts = (try? button.labelView().findAll(ViewType.Text.self).compactMap { try? $0.string(locale: ja) }) ?? []
+            return labelTexts.contains("新しい子供を追加")
+        }
+        XCTAssertEqual(
+            ctaButtons.count, 1,
+            "CTA ボタンが 1 個であること。buttons: \(buttons.count) 個, rendered texts: \(texts)"
+        )
+    }
     
     @MainActor
     func testHomeViewDisplaysUnpaidWarningBanner() throws {

--- a/app/OtetsudaiCoinTests/Presentation/Views/HomeViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Views/HomeViewTests.swift
@@ -7,6 +7,7 @@ import UIKit
 
 final class HomeViewTests: XCTestCase {
     private var viewModel: HomeViewModel!
+    private var childManagementViewModel: ChildManagementViewModel!
     private var mockChildRepository: MockChildRepository!
     private var mockHelpRecordRepository: MockHelpRecordRepository!
     private var mockHelpTaskRepository: MockHelpTaskRepository!
@@ -29,9 +30,11 @@ final class HomeViewTests: XCTestCase {
             allowanceCalculator: mockAllowanceCalculator,
             allowancePaymentRepository: mockAllowancePaymentRepository
         )
+        childManagementViewModel = ChildManagementViewModel(childRepository: mockChildRepository)
     }
-    
+
     override func tearDown() {
+        childManagementViewModel = nil
         viewModel = nil
         mockAllowancePaymentRepository = nil
         mockAllowanceCalculator = nil
@@ -49,7 +52,7 @@ final class HomeViewTests: XCTestCase {
         ]
         viewModel.children = children
         
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
         
         // LazyVStackを使用しているため、テキストの存在を直接確認
         XCTAssertNoThrow(try view.inspect().find(text: "太郎"))
@@ -71,14 +74,14 @@ final class HomeViewTests: XCTestCase {
         XCTAssertEqual(viewModel.totalRecordsThisMonth, 8)
         
         // Viewが作成できることを確認
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
         XCTAssertNotNil(view)
     }
     
     @MainActor
     func testHomeViewDisplaysLoadingState() throws {
         // @Observableでは状態を直接変更できないため、テストを簡略化
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
         
         XCTAssertNotNil(view)
     }
@@ -86,7 +89,7 @@ final class HomeViewTests: XCTestCase {
     @MainActor
     func testHomeViewDisplaysErrorMessage() throws {
         // @Observableでは状態を直接変更できないため、テストを簡略化
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
         
         XCTAssertNotNil(view)
     }
@@ -99,7 +102,7 @@ final class HomeViewTests: XCTestCase {
         ]
         viewModel.children = children
         
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
         
         // LazyVStackの中のボタンを探す
         let button = try view.inspect().find(ViewType.Button.self, containing: "太郎")
@@ -113,7 +116,7 @@ final class HomeViewTests: XCTestCase {
     func testHomeViewDisplaysEmptyStateWhenNoChildren() throws {
         viewModel.children = []
         
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
         
         XCTAssertNoThrow(try view.inspect().find(text: "お子様を登録してください", locale: Locale(identifier: "ja")))
     }
@@ -132,7 +135,7 @@ final class HomeViewTests: XCTestCase {
         viewModel.unpaidWarningMessage = "12月分のお小遣いが未払いです"
         viewModel.totalUnpaidAmount = 500
         
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
         
         // 未支払い警告バナーの表示をテスト
         XCTAssertNoThrow(try view.inspect().find(text: "未支払いのお小遣いがあります", locale: Locale(identifier: "ja")))
@@ -154,7 +157,7 @@ final class HomeViewTests: XCTestCase {
         viewModel.unpaidWarningMessage = "太郎の未支払いのお小遣いが500コインあります。"
         viewModel.totalUnpaidAmount = 500
 
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
 
         // バナーが表示されること
         XCTAssertNoThrow(try view.inspect().find(text: "未支払いのお小遣いがあります", locale: Locale(identifier: "ja")))
@@ -173,7 +176,7 @@ final class HomeViewTests: XCTestCase {
         viewModel.showUnpaidWarning = false
         viewModel.totalUnpaidAmount = 0
         
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
         
         // 未支払い警告バナーが表示されないことをテスト
         XCTAssertThrowsError(try view.inspect().find(text: "未支払いのお小遣いがあります", locale: Locale(identifier: "ja")))
@@ -183,7 +186,7 @@ final class HomeViewTests: XCTestCase {
     
     @MainActor
     func testHomeViewUsesNavigationStack() throws {
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
         
         // NavigationStackが使用されていることを確認
         XCTAssertNoThrow(try view.inspect().find(ViewType.NavigationStack.self))
@@ -198,7 +201,7 @@ final class HomeViewTests: XCTestCase {
         viewModel.selectedChild = child
         viewModel.children = [child]
         
-        let view = HomeView(viewModel: viewModel)
+        let view = HomeView(viewModel: viewModel, childManagementViewModel: childManagementViewModel)
         
         // Viewが正常に作成されることを確認（レスポンシブレイアウト対応）
         XCTAssertNotNil(view)


### PR DESCRIPTION
## 概要

Issue #149 のコメント (2026-07-05) で追加報告された「子ども 0 人時の Home 空状態に CTA がない」問題のみを修正する。#149 本体 (月間サマリーカード等の情報設計) はデザイン判断待ちのためスコープ外。

Refs #149

## 変更点

- `HomeView.swift`: 空状態 (「お子様を登録してください」) に「新しい子供を追加」CTA ボタンを追加。tap で `ChildFormView(viewModel: childManagementViewModel, editingChild: nil)` を `.sheet` 表示 (SettingsView の追加フローと同じ形)。スタイルは履歴画面の空状態 CTA と同じ `.primaryButton()` (#175 の SolidButtonStyle 統一に整合)。
- `HomeView` に `childManagementViewModel` パラメータを追加 (pass-through、`let`)。
- `ContentView.swift:75`: `HomeView(viewModel:childManagementViewModel:)` の 1 行変更で配線。
- `HomeViewTests.swift`: 新シグネチャへの全 call site 更新 (11 箇所) + 新テスト `testHomeViewEmptyStateShowsAddChildCTA` 追加。

## ラベルキー再利用

新キー追加なし (**xcstrings 変更ゼロ**)。SettingsView:95 と同じ既存キー「新しい子供を追加」を再利用 (en 訳 "Add New Child" が `Localizable.xcstrings:1761` に既存)。

## リロード経路の確認結果 (健全)

子ども追加 → Home 自動リフレッシュの経路はコードで確認済み・変更不要:

1. `ChildFormView` 保存 → `ChildManagementViewModel.addChild()` が `NotificationManager.shared.notifyChildrenUpdated()` を発火 (`ChildManagementViewModel.swift:87`)
2. `HomeViewModel.setupNotificationListeners()` (`HomeViewModel.swift:48`) が `observeChildrenUpdates` で listen → `loadChildren()` 実行

よって CTA からの追加後、Home は空状態から自動で子どもリストへ切替わる。

## テスト (TDD)

- **RED**: `testHomeViewEmptyStateShowsAddChildCTA` を実装前に実行し fail を確認 (`** TEST FAILED **`、失敗は新テストのみ)。
- **GREEN**: 実装後 `HomeViewTests` 全 pass → **unit 全体 (`-only-testing:OtetsudaiCoinTests`) で `** TEST SUCCEEDED **`** を確認。
- テスト設計: 空状態に `Image(systemName:)` + `.foregroundColor` (AccessibilityImageLabel blocker) があるため、`find(viewWithAccessibilityIdentifier:)` を使わず **findAll ベース** (`findAll(ViewType.Text.self)` / `findAll(ViewType.Button.self)` を label Text でフィルタ)。assertion message に rendered texts / button 数を dump。
- GREEN 初回失敗の切り分け: test host が en locale でキー解決し `"Add New Child"` が返っていた (dump で即判明)。既存テストの `find(text:locale: ja)` と同様に `string(locale: ja)` 指定で解決。

## Plan からの逸脱

- **commit 構成**: 新パラメータ追加はコンパイルエラー確定 RED になるため、配線のみの refactor commit (green 維持) を先行させ、CTA 存在 assert を**実行可能な behavioral RED** として確認する 2 commit 構成にした。
- **simulator**: dispatch 指定の `iPhone 16` がこの環境に存在しないため `iPhone 17` (id 指定) で実行。
- tap → sheet 表示の assert は非 hosted View で `@State` が保持されないため presence テストまでを境界とした (既存 smoke テストと合わせ間接担保)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QgGa9UrU4VMU4PtYZk5oM