### PR TITLE
docs(#177): リリース手順書に Core Data v3→v4 migration の spot-check を追加

### DIFF
--- a/docs/releases/APP_STORE_SUBMISSION_GUIDE.md
+++ b/docs/releases/APP_STORE_SUBMISSION_GUIDE.md
@@ -196,6 +196,7 @@ OtetsudaiCoin - お手伝いコイン
 - [ ] Archive & Export 成功確認
 - [ ] App Store Connect上でアプリ作成完了
 - [ ] TestFlight配信テスト完了
+- [ ] **Core Data モデルを変更したリリースでは、旧モデル入りの実機/シミュレータへ上書きインストールして migration を spot-check**（in-memory の roundtrip テストが green でも、実ディスク上の旧ストアを開く経路は未実測のため）
 
 ### App Store Connect設定
 - [ ] アプリ情報入力完了

--- a/docs/releases/RELEASE_v1.1.3.md
+++ b/docs/releases/RELEASE_v1.1.3.md
@@ -230,6 +230,7 @@ en Description / What's New に絵文字を入れない。本ドキュメント 
 - [ ] 対応 issue (#89 / その他 v1.1.2 で close 漏れの issue) を `gh issue close <N> --reason completed --comment "v1.1.3 でリリース"` で処理
 - [ ] v1.1.1 用の GitHub Release を「Latest」マークから外し、v1.1.3 をマーク
 - [ ] `release-retrospective` skill を実行 (v1.1.2 → v1.1.3 の reject と再提出フローの振り返り、特に **同じ ITMS reject を 2 回踏んだ理由** を skill/CI で更にどう塞ぐか検討)
+- [ ] **次リリース手順書 (本ドキュメントをベースに作成) の § 3 コード / プロジェクトへ「Core Data migration spot-check」を追加する** ← #177 項目4。v1.1.3 は model v3 で出荷したが、次リリースは **model v4 の初出荷** (#148 PR #176 で v3→v4 の additive optional 属性を追加) となる。in-memory roundtrip テストは green だが**実ディスク上の v3 ストアを開く経路は未実測**のため、`v1.1.3 (model v3) をインストール済みのシミュレータへ新ビルドを上書き起動し、既存データが消えない / クラッシュしない ことを目視確認する` チェック項目を必ず置く (版非依存の記載は `APP_STORE_SUBMISSION_GUIDE.md` § 提出前チェックリスト § 技術的要件 にもあり)
 
 ## 6. 振り返り (Retrospective)
 


### PR DESCRIPTION
## 概要

#177 項目4（優先: 次リリース前）に対応します。#148 (PR #176) で Core Data model を v3 → v4 へ追加しましたが、**実ディスク上の v3 ストアを開く経路が未実測**のままです。次リリースは model v4 の初出荷になるため、提出前チェックリストに migration の spot-check を組み込みます。

## 変更内容

| ファイル | 追加内容 |
|---|---|
| `docs/releases/APP_STORE_SUBMISSION_GUIDE.md` § 提出前チェックリスト § 技術的要件 | **版非依存の条件付き項目**「Core Data モデルを変更したリリースでは、旧モデル入りの実機/シミュレータへ上書きインストールして migration を spot-check」 |
| `docs/releases/RELEASE_v1.1.3.md` § 5 完了後タスク | 次リリース手順書（本書をベースに作成される）の § 3 へ具体項目を引き継ぐ指示 |

## 配置の判断

リリース手順書は `RELEASE_v1.1.2.md` → `RELEASE_v1.1.3.md` のように**前バージョンをコピーして作る**運用（v1.1.3 冒頭に明記）なので、次リリース版へ確実に伝搬させるには v1.1.3 に書く必要があります。ただし v1.1.3 は既に model v3 で出荷済みで、§ 3 提出前チェックリストに未チェック項目を足すと「やり残し」に見えてしまうため、**§ 5 完了後タスクへ「次の手順書に入れる」形の引き継ぎ項目**として置きました。版非依存の恒久的な記載は `APP_STORE_SUBMISSION_GUIDE.md` 側に持たせています（#86 Age Rating が「ガイドの汎用項目 + 手順書の具体項目」の二段構えになっている既存パターンに合わせました）。

## 検証

- `find app -name .xccurrentversion` で現行モデルが `OtetsudaiCoin 4.xcdatamodel` (= v4) であることを確認
- `docs/releases/` に既存の migration spot-check 記載が無いことを grep で確認（重複追記なし）
- ドキュメントのみの変更でコード差分なし

Refs #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CdWTw9S8g5Ftxk1icasq6