### PR TITLE
fix(#151): SF Symbol アイコンの .blue をブランドカラー (brandPrimary) へ統一

### DIFF
--- a/app/OtetsudaiCoin/Presentation/Views/ChildFormView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/ChildFormView.swift
@@ -20,7 +20,7 @@ struct ChildFormView: View {
                 Section("基本情報") {
                     HStack {
                         Image(systemName: "person.circle.fill")
-                            .foregroundColor(.blue)
+                            .foregroundColor(AccessibilityColors.brandPrimary)
                             .font(.title2)
                         
                         TextField("お子様のお名前", text: $name)

--- a/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
@@ -381,7 +381,7 @@ struct HelpRecordRow: View {
                 Button(action: onEdit) {
                     Image(systemName: "pencil")
                         .font(.system(size: 16))
-                        .foregroundColor(.blue)
+                        .foregroundColor(AccessibilityColors.brandPrimary)
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }

--- a/app/OtetsudaiCoin/Presentation/Views/HelpRecordEditView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HelpRecordEditView.swift
@@ -185,7 +185,7 @@ struct TaskSelectionRow: View {
                 if isSelected {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.title3)
-                        .foregroundColor(.blue)
+                        .foregroundColor(AccessibilityColors.brandPrimary)
                 }
             }
             .padding(.vertical, 4)

--- a/app/OtetsudaiCoin/Presentation/Views/SettingsView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/SettingsView.swift
@@ -105,7 +105,7 @@ struct SettingsView: View {
                     }) {
                         HStack {
                             Image(systemName: "list.bullet.clipboard")
-                                .foregroundColor(.blue)
+                                .foregroundColor(AccessibilityColors.brandPrimary)
                             Text("お手伝いリストを編集")
                             Spacer()
                             Image(systemName: "chevron.right")
@@ -216,7 +216,7 @@ struct SettingsView: View {
                 Section("アプリ情報") {
                     HStack {
                         Image(systemName: "info.circle")
-                            .foregroundColor(.blue)
+                            .foregroundColor(AccessibilityColors.brandPrimary)
                         Text("バージョン")
                         Spacer()
                         Text(appVersionText)
@@ -233,7 +233,7 @@ struct SettingsView: View {
                         }) {
                             HStack {
                                 Image(systemName: "arrow.up.right.square")
-                                    .foregroundColor(.blue)
+                                    .foregroundColor(AccessibilityColors.brandPrimary)
                                 Text("App Store でレビューする")
                                 Spacer()
                                 Image(systemName: "chevron.right")

--- a/app/OtetsudaiCoin/Presentation/Views/Tutorial/ChildTutorialView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/Tutorial/ChildTutorialView.swift
@@ -125,7 +125,7 @@ struct ChildTutorialView: View {
         VStack(spacing: 24) {
             Image(systemName: "person.circle.fill")
                 .font(.system(size: 80))
-                .foregroundColor(.blue)
+                .foregroundColor(AccessibilityColors.brandPrimary)
             
             Text("最初のお子様を\n登録しましょう")
                 .font(.largeTitle)
@@ -250,7 +250,7 @@ struct FeatureRow: View {
         HStack(spacing: 16) {
             Image(systemName: icon)
                 .font(.title2)
-                .foregroundColor(.blue)
+                .foregroundColor(AccessibilityColors.brandPrimary)
                 .frame(width: 30)
             
             VStack(alignment: .leading, spacing: 4) {

--- a/app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift
@@ -148,7 +148,7 @@ struct RecordTutorialView: View {
         VStack(spacing: 24) {
             Image(systemName: "person.2.circle.fill")
                 .font(.system(size: 80))
-                .foregroundColor(.blue)
+                .foregroundColor(AccessibilityColors.brandPrimary)
             
             Text("お子様を選択")
                 .font(.largeTitle)
@@ -518,7 +518,7 @@ struct CompletionFeature: View {
         HStack(spacing: 16) {
             Image(systemName: icon)
                 .font(.title2)
-                .foregroundColor(.blue)
+                .foregroundColor(AccessibilityColors.brandPrimary)
                 .frame(width: 30)
             
             VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
## 概要

#175 Finding 2（2026-08-08 に #151 へ合流）の対応です。設定画面ほかの SF Symbol アイコンが生の `.blue` のままで、#147 で確立したブランドカラー（オレンジ × ティール）から浮いていました。**SF Symbol アイコンの `.foregroundColor(.blue)` 10 箇所**を `AccessibilityColors.brandPrimary` (`#E8590C`) へ置換します。

## 変更箇所

| ファイル | 対象 |
|---|---|
| `SettingsView.swift` ×3 | お手伝いリストを編集 (clipboard) / バージョン (info.circle) / App Store レビュー導線 |
| `HelpHistoryView.swift` | 履歴行の編集ボタン (pencil) |
| `HelpRecordEditView.swift` | タスク選択インジケータ (checkmark.circle.fill) |
| `ChildFormView.swift` | お名前欄アイコン (person.circle.fill) |
| `ChildTutorialView.swift` ×2 | 見出しアイコン + FeatureRow アイコン |
| `RecordTutorialView.swift` ×2 | 見出しアイコン + FeatureRow アイコン |

## スコープの線引き

#151 の色監査本体（デザイン判断を伴う部分）へ意図的に残したものです。

- **テーマ色の fallback (`Color(hex: child.themeColor) ?? .blue`)**: 子どもごとのテーマ色が解決できなかった場合の保険であり、アイコンの固定色とは意味が別物なので対象外
- **`AccessibilityColors` の `primaryBlue` / `focusIndicator` 定義**: #151「ダークモード 3（固定 hex の asset catalog 適応色化）」の作業対象
- **`TaskManagementView.swift:136` の `.blue`**: SF Symbol ではなく**コイン数の Text**。コイン表現の色は #155（¥/コイン表記統一）と重なるため本 PR では触っていません

## 検証

- ユニットテスト green: `xcodebuild test -only-testing:OtetsudaiCoinTests -destination 'platform=iOS Simulator,name=iPhone 17'` → `** TEST SUCCEEDED **`
- 事前に両テストターゲットを grep し、対象色を pin しているアサーションが無いことを確認（`ChildCardViewTests` の `?? .blue` はテーマ色 fallback で本 PR 非対象）
- **視覚確認**: `scripts/capture-asc-screenshots.sh` で 03-settings を撮影して目視（clipboard アイコンが CTA ボタン・タブバーと同じブランドオレンジになり、青の浮きが解消）。出力スクショは ASC 提出物なので `git checkout -- docs/screenshots/` で破棄しており、本 PR には含めていません
- SettingsView は ViewInspector の traverse 不可制約（CLAUDE.md 記載）があるため structural test は追加していません

## 検証の境界 / out-of-scope finding

- **ブランドオレンジ (`#E8590C`) とシステム `.orange` が同一画面に併存**します（設定画面の通知ベル・データ削除・ヘルプアイコンは生の `.orange` のまま）。スクショ目視では両方とも暖色で破綻はありませんが、ベルの方がやや明るい橙で色差があります。アイコン1つ1つの意味づけ（brandPrimary / warningOrange / errorRed のどれを当てるか）はデザイン判断なので、**#151 の色監査本体**で扱うべき残課題として記録します
- ASC スクショは ホーム / 記録 / 設定 の 3 画面のみのため、**履歴・記録編集・お子様フォーム・チュートリアルの変更はコードレビューのみ**です（スクショ再撮影は次リリース時）
- 履歴行の編集(オレンジ)と削除(赤)が隣接するため、次にこれらの画面を撮影する際に視認性を確認してください

Refs #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CdWTw9S8g5Ftxk1icasq6