### PR TITLE
chore(#154): SWIFT_STRICT_CONCURRENCY を targeted へ引き上げ、新規 warning を解消

### DIFF
--- a/app/OtetsudaiCoin.xcodeproj/project.pbxproj
+++ b/app/OtetsudaiCoin.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = targeted;
 			};
 			name = Debug;
 		};
@@ -421,6 +422,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_STRICT_CONCURRENCY = targeted;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/app/OtetsudaiCoin/Presentation/ViewModels/HomeViewModel.swift
+++ b/app/OtetsudaiCoin/Presentation/ViewModels/HomeViewModel.swift
@@ -120,14 +120,14 @@ class HomeViewModel: BaseViewModel {
                 // 処理開始時の選択された子供を保持
                 let processChild = child
 
-                // データ取得を並行処理で高速化
-                async let recordsTask = helpRecordRepository.findByChildIdInCurrentMonth(processChild.id)
-                async let tasksTask = helpTaskRepository.findAll()
-                async let paymentTask = getCurrentMonthPayment(for: processChild.id)
-
-                let records = try await recordsTask
-                let tasks = try await tasksTask
-                let payment = try await paymentTask
+                // #154 (strict concurrency targeted): リポジトリは非 Sendable のため
+                // `async let` の子タスク (非隔離) へ送れない。逐次 await へ変更する。
+                // 各 fetch は Core Data の background context 上で走るのでメインスレッドは
+                // ブロックせず、コストは「最大値」から「合計値」への増分のみ。
+                // リポジトリの Sendable 化は complete 段階でまとめて扱う。
+                let records = try await helpRecordRepository.findByChildIdInCurrentMonth(processChild.id)
+                let tasks = try await helpTaskRepository.findAll()
+                let payment = try await getCurrentMonthPayment(for: processChild.id)
 
                 // タスクがキャンセルされていないか、選択された子供が変更されていないか確認
                 guard !Task.isCancelled, selectedChild?.id == processChild.id else {

--- a/app/OtetsudaiCoinTests/Presentation/ViewModels/TaskManagementViewModelTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/ViewModels/TaskManagementViewModelTests.swift
@@ -236,9 +236,12 @@ final class TaskManagementViewModelTests: XCTestCase {
 
         // 2 つの並べ替えをほぼ同時に発火。直列化されていれば updateSortOrders は
         // 同時に 1 つしか走らない (#130-①)。
-        async let first: Void = viewModel.moveTasks(from: IndexSet(integer: 2), to: 0)
-        async let second: Void = viewModel.moveTasks(from: IndexSet(integer: 0), to: 2)
-        _ = await (first, second)
+        // #154: `async let` の子タスクは非隔離のため、非 Sendable な viewModel を
+        // 送れない。`Task` は囲みの @MainActor を継承するので隔離を跨がずに
+        // 「await せず 2 つ発火 → 両方待つ」という同時実行の意図を保てる。
+        let first = Task { await viewModel.moveTasks(from: IndexSet(integer: 2), to: 0) }
+        let second = Task { await viewModel.moveTasks(from: IndexSet(integer: 0), to: 2) }
+        _ = await (first.value, second.value)
 
         XCTAssertLessThanOrEqual(
             mockTaskRepository.maxConcurrentUpdateSortOrders, 1,

--- a/app/OtetsudaiCoinTests/Presentation/ViewModels/ViewModelObservationTrackingTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/ViewModels/ViewModelObservationTrackingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Observation
+import os
 @testable import OtetsudaiCoin
 
 /// `BaseViewModel` を継承した ViewModel の「サブクラスで新規宣言した stored property」が
@@ -24,14 +25,17 @@ final class ViewModelObservationTrackingTests: XCTestCase {
         access: () -> Void,
         mutate: () -> Void
     ) -> Bool {
-        var fired = false
+        // #154: `onChange` は @Sendable クロージャなので、ローカル var を直接
+        // 書き換えると strict concurrency 警告 (Swift 6 ではエラー) になる。
+        // 発火は同期なので、Sendable な lock 越しの boolean で受ける。
+        let fired = OSAllocatedUnfairLock(initialState: false)
         withObservationTracking {
             access()
         } onChange: {
-            fired = true
+            fired.withLock { $0 = true }
         }
         mutate()
-        return fired
+        return fired.withLock { $0 }
     }
 
     // MARK: - ChildManagementViewModel（サブクラスで `children` を宣言）


### PR DESCRIPTION
## 概要

#154「Swift 6 / strict concurrency への段階移行」の **step 1（`targeted` → warning 掃除）** です。

### 依存が既に解消されていました

issue 本文は「優先: 低（#142 / #152 系の後で OK）」「`InMemoryAllowancePaymentRepository` に `@unchecked Sendable` あり（#142 の Core Data 移行で解消見込み）」としていますが、**#142 は merge 済みで `@unchecked Sendable` はリポジトリ全体で grep 0 件**でした。ブロッカーは既に外れています。

## 変更内容

### 1. ビルド設定

プロジェクトレベルの Debug / Release 双方へ `SWIFT_STRICT_CONCURRENCY = targeted` を追加。app / Tests / UITests の 3 ターゲットすべてへ継承されることを `xcodebuild -showBuildSettings` で確認済みです。

### 2. warning 解消（新規に出た 9 件 = 実質 3 箇所）

| 箇所 | 内容 | 対応 |
|---|---|---|
| `HomeViewModel.refreshData:124-126` | 非 Sendable なリポジトリを `async let` の子タスク（非隔離）へ送れない | **逐次 await 化**（下記トレードオフ参照） |
| `TaskManagementViewModelTests:239-240` | `async let` が非 Sendable な `viewModel` を子タスクへ送る | `Task` へ置換。`Task` は囲みの `@MainActor` を継承するため、「await せず 2 つ発火 → 両方待つ」という同時実行の意図を保ったまま隔離を跨がない |
| `ViewModelObservationTrackingTests:31` | `@Sendable` な `onChange` 内でローカル var を書き換え（strict concurrency 以前から存在、Swift 6 では確定エラー） | `OSAllocatedUnfairLock` 経由へ変更 |

## トレードオフ: HomeViewModel の並行 fetch を逐次化

`async let` による 3 本の並行 fetch を逐次 `await` へ変更しました。

- **なぜ Sendable 化しないか**: リポジトリ protocol を `Sendable` にすると、`NSManagedObjectContext` を保持する Core Data 実装に `@unchecked Sendable` が必要になり、**#142 が意図的に取り除いた注釈を復活させる**ことになります。さらに protocol の `Sendable` 化はテスト側の mock 全部へ波及します。これは step 2（`complete`）でのリポジトリ層一括監査の作業であり、フラグを上げるだけの本 PR に混ぜるべきではないと判断しました
- **コスト**: 各 fetch は Core Data の background context 上で走るためメインスレッドはブロックせず、増分は「3 本の最大値 → 合計値」の差（ローカルストアの fetch なので ms オーダー）です
- **step 2 では不可避**: `complete` にすると通常の `await repo.foo()` も同じ理由で warning になるため、リポジトリの Sendable 監査はいずれ必要です。コード内コメントにもその旨を残しています

## 検証

| 項目 | 結果 |
|---|---|
| クリーンビルド（専用 derivedDataPath、`build-for-testing`） | `** TEST BUILD SUCCEEDED **` |
| concurrency 系 warning | **0 件**（`sendable\|concurren\|isolat\|captured var` で grep） |
| ユニットテスト全体 | `** TEST SUCCEEDED **` |
| 変更したテスト 2 件 | `testConcurrentReordersAreSerialized` / `ViewModelObservationTrackingTests` 3 件いずれも passed を個別に確認 |

計測は baseline（`minimal`）と `targeted` の**クリーンビルド同士を比較**しています（初回はインクリメンタルビルドで警告が出ず誤判定しかけたため、専用 derivedDataPath で取り直しました）。

## スコープ外（残件を明示）

- **strict concurrency 以前から存在するテスト側 warning 12 件**（`nil coalescing operator '??' has non-optional type` ×4、`no calls to throwing functions occur within 'try'` ×8）は本 PR では触っていません。concurrency 起因ではないため別途対応。
- **step 2 (`complete`) / step 3 (Swift 6 言語モード)** は #154 に残ります。リポジトリ層の Sendable 監査が本丸です。

Refs #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CdWTw9S8g5Ftxk1icasq6