### PR TITLE
refactor(#200)/perf(#201): TaskIconView 共通化 + timeString formatter cache 化

### DIFF
--- a/app/OtetsudaiCoin/Presentation/Components/TaskCardView.swift
+++ b/app/OtetsudaiCoin/Presentation/Components/TaskCardView.swift
@@ -56,16 +56,8 @@ struct TaskCardView: View {
     }
 
     private var taskIcon: some View {
-        ZStack {
-            Circle()
-                .fill(isSelected ? AccessibilityColors.brandPrimary.opacity(0.15) : Color.gray.opacity(0.1))
-                .frame(width: 50, height: 50)
-
-            // 絵文字は装飾。カードの意味は taskTitle が担うため VoiceOver から隠す (#84 パターン)
-            Text(task.displayIcon)
-                .font(.title2)
-                .accessibilityHidden(true)
-        }
+        // ZStack + 非拘束 Text / VoiceOver hidden / 円塗りトークンは TaskIconView に集約 (#200)
+        TaskIconView(task: task, isSelected: isSelected)
     }
 
     private var taskTitle: some View {

--- a/app/OtetsudaiCoin/Presentation/Components/TaskIconView.swift
+++ b/app/OtetsudaiCoin/Presentation/Components/TaskIconView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// displayIcon 絵文字 + 選択状態の円塗りを表示する共通アイコン (#200)。
+///
+/// TaskCardView / TutorialTaskCardView / TaskSelectionRow で verbatim 重複していた
+/// ZStack + Circle + Text を集約する。tint / font 変更時の追随がここ 1 箇所で済む。
+///
+/// - ZStack + 非拘束 Text: 固定 frame + overlay/background だと AX サイズの
+///   Dynamic Type で絵文字が truncate する (#177 PR #198 で確立したパターン)。
+/// - 絵文字は装飾。意味は隣接する displayName の Text が担うため VoiceOver から隠す (#84 パターン)。
+struct TaskIconView: View {
+    let task: HelpTask
+    let isSelected: Bool
+    var size: CGFloat = 50
+    var font: Font = .title2
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(isSelected
+                    ? AccessibilityColors.taskIconSelectedFill
+                    : AccessibilityColors.taskIconUnselectedFill)
+                .frame(width: size, height: size)
+
+            Text(task.displayIcon)
+                .font(font)
+                .accessibilityHidden(true)
+        }
+    }
+}

--- a/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift
@@ -260,16 +260,35 @@ struct HelpHistoryView: View {
         makeDayGroupFormatter(locale: locale).string(from: date)
     }
 
+    /// 記録時刻 formatter の locale 別 cache (#201)。
+    /// 旧実装は呼び出し (= HelpRecordRow の行 render) ごとに DateFormatter を生成しており、
+    /// 長い履歴リストのスクロールで全可視行分の生成+設定コストが発生していた。
+    /// View body (= MainActor) からしか呼ばれないため @MainActor で隔離し、
+    /// 素の static var の data race を避ける。
+    @MainActor
+    private static var timeFormatterCache: [String: DateFormatter] = [:]
+
+    /// locale に対応する時刻 formatter を返す (cache 済みなら再利用)。
+    @MainActor
+    static func timeFormatter(locale: Locale) -> DateFormatter {
+        if let cached = timeFormatterCache[locale.identifier] {
+            return cached
+        }
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.locale = locale
+        timeFormatterCache[locale.identifier] = formatter
+        return formatter
+    }
+
     /// 記録時刻を locale に応じて生成する (#155 コメント報告の i18n 漏れ対応)。
     ///
     /// 旧実装は `HelpRecordRow` 内の private func で ja_JP 固定になっており、
     /// en ロケールでも 24 時間表記が強制されていた。`.short` スタイルは
     /// ja で「9:05」(現行と同一)、en で「9:05 AM」になる。
+    @MainActor
     static func timeString(from date: Date, locale: Locale) -> String {
-        let formatter = DateFormatter()
-        formatter.timeStyle = .short
-        formatter.locale = locale
-        return formatter.string(from: date)
+        timeFormatter(locale: locale).string(from: date)
     }
     
     private func createEditView(for record: HelpRecordWithDetails) -> some View {

--- a/app/OtetsudaiCoin/Presentation/Views/HelpRecordEditView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/HelpRecordEditView.swift
@@ -156,21 +156,9 @@ struct TaskSelectionRow: View {
     var body: some View {
         Button(action: onSelect) {
             HStack {
-                // タスクアイコン
-                // #177 項目5: displayIcon 絵文字 (#148 のカードデザイン展開)。
-                // 円の塗りは TaskCardView と同型 (絵文字の上に青塗りは意味を失うため、
-                // 白/青 SF Symbol デザインから brandPrimary 0.15 / gray 0.1 へ揃える)。
-                // ZStack + 非拘束 Text (TaskCardView パターン): 固定 frame + background だと
-                // AX サイズの Dynamic Type で絵文字が truncate する。
-                // 絵文字は装飾。行の意味は displayName の Text が担うため VoiceOver から隠す (#84 パターン)
-                ZStack {
-                    Circle()
-                        .fill(isSelected ? AccessibilityColors.brandPrimary.opacity(0.15) : Color.gray.opacity(0.1))
-                        .frame(width: 32, height: 32)
-                    Text(task.displayIcon)
-                        .font(.title3)
-                        .accessibilityHidden(true)
-                }
+                // タスクアイコン (32pt / .title3 は行レイアウト用の縮小版)。
+                // ZStack + 非拘束 Text / VoiceOver hidden / 円塗りトークンは TaskIconView に集約 (#200)
+                TaskIconView(task: task, isSelected: isSelected, size: 32, font: .title3)
                 
                 // タスク情報
                 VStack(alignment: .leading, spacing: 4) {

--- a/app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift
+++ b/app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift
@@ -433,17 +433,8 @@ struct TutorialTaskCardView: View {
     var body: some View {
         Button(action: onTap) {
             VStack(spacing: 12) {
-                ZStack {
-                    Circle()
-                        .fill(isSelected ? AccessibilityColors.brandPrimary.opacity(0.15) : Color.gray.opacity(0.1))
-                        .frame(width: 50, height: 50)
-
-                    // 絵文字は装飾。カードの意味は displayName の Text が担うため VoiceOver から隠す
-                    // (TaskCardView と同型、#84 パターン)
-                    Text(task.displayIcon)
-                        .font(.title2)
-                        .accessibilityHidden(true)
-                }
+                // ZStack + 非拘束 Text / VoiceOver hidden / 円塗りトークンは TaskIconView に集約 (#200)
+                TaskIconView(task: task, isSelected: isSelected)
 
                 Text(task.displayName)
                     .font(.caption)

--- a/app/OtetsudaiCoin/Utils/AccessibilityColors.swift
+++ b/app/OtetsudaiCoin/Utils/AccessibilityColors.swift
@@ -131,6 +131,12 @@ struct AccessibilityColors {
     /// 温色の淡背景。
     static let brandSurfaceWarm = Color(hex: "#FFF4E6") ?? .orange.opacity(0.1)
 
+    /// タスクアイコン円の塗り (選択時)。TaskIconView で使用 (#200 で 3 site から hoist)。
+    static let taskIconSelectedFill = brandPrimary.opacity(0.15)
+
+    /// タスクアイコン円の塗り (非選択時)。TaskIconView で使用 (#200 で 3 site から hoist)。
+    static let taskIconUnselectedFill = Color.gray.opacity(0.1)
+
     // MARK: - Utility Functions
     
     /// 指定された背景色に対して最適なテキスト色を返す

--- a/app/OtetsudaiCoinTests/Helpers/ViewInspectorHelpers.swift
+++ b/app/OtetsudaiCoinTests/Helpers/ViewInspectorHelpers.swift
@@ -29,8 +29,8 @@ extension XCTestCase {
     ) throws {
         let fills = try view.renderedFills()
         XCTAssertTrue(
-            fills.contains(AccessibilityColors.brandPrimary.opacity(0.15)),
-            "アイコン円の brandPrimary 0.15 が無い / observed fills: \(fills)", file: file, line: line
+            fills.contains(AccessibilityColors.taskIconSelectedFill),
+            "アイコン円の taskIconSelectedFill が無い / observed fills: \(fills)", file: file, line: line
         )
         XCTAssertTrue(
             fills.contains(AccessibilityColors.brandPrimary.opacity(0.1)),

--- a/app/OtetsudaiCoinTests/Helpers/ViewInspectorHelpers.swift
+++ b/app/OtetsudaiCoinTests/Helpers/ViewInspectorHelpers.swift
@@ -1,0 +1,40 @@
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import OtetsudaiCoin
+
+/// ViewInspector 共通 helper (#200)。
+/// `find(viewWithAccessibilityIdentifier:)` は ViewInspector 0.10.2 + iOS 26 SDK で
+/// systematic に効かない既知回帰があるため (CLAUDE.md「SwiftUI View テスト戦略」節)、
+/// findAll ベースで blocker を跨いで収集するパターンを 1 箇所に固定する。
+@MainActor
+extension View {
+    /// 描画された全 Text の文字列を列挙する。
+    func renderedTexts() throws -> [String] {
+        try inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+    }
+
+    /// 描画された全 Shape の fill 色を列挙する。
+    func renderedFills() throws -> [Color] {
+        try inspect().findAll(ViewType.Shape.self).compactMap { try? $0.fillShapeStyle(Color.self) }
+    }
+}
+
+extension XCTestCase {
+    /// #177 項目7 で確立した AND assert (アイコン円 0.15 + カード背景 0.1 を個別検証) の共通化 (#200)。
+    /// OR だと片方だけの色 regression を検出できない。両辺の検出力は PR #198 の mutation 検証で実証済み。
+    @MainActor
+    func assertBrandPrimaryIconAndCardFills(
+        _ view: some View, file: StaticString = #filePath, line: UInt = #line
+    ) throws {
+        let fills = try view.renderedFills()
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.brandPrimary.opacity(0.15)),
+            "アイコン円の brandPrimary 0.15 が無い / observed fills: \(fills)", file: file, line: line
+        )
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.brandPrimary.opacity(0.1)),
+            "カード背景の brandPrimary 0.1 が無い / observed fills: \(fills)", file: file, line: line
+        )
+    }
+}

--- a/app/OtetsudaiCoinTests/Presentation/Components/HelpRecordRowTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/HelpRecordRowTests.swift
@@ -96,14 +96,14 @@ final class HelpRecordRowTests: XCTestCase {
     /// #177 項目5: 行頭アイコンはタスクの displayIcon 絵文字を表示する (#148 の展開)。
     func test_rowIcon_rendersExplicitIconEmoji() throws {
         let view = makeView(taskIcon: "🧹")
-        let texts = try view.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+        let texts = try view.renderedTexts()
         XCTAssertTrue(texts.contains("🧹"), "rendered: \(texts)")
     }
 
     /// icon 未設定 & 辞書外名は ✨ へフォールバックする (displayIcon の既定挙動が row に配線されていること)。
     func test_rowIcon_fallsBackToSparkleForUnknownName() throws {
         let view = makeView(taskName: "辞書に無い独自タスク")
-        let texts = try view.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+        let texts = try view.renderedTexts()
         XCTAssertTrue(texts.contains("✨"), "rendered: \(texts)")
     }
 }

--- a/app/OtetsudaiCoinTests/Presentation/Components/TaskCardViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/TaskCardViewTests.swift
@@ -10,15 +10,6 @@ final class TaskCardViewTests: XCTestCase {
         HelpTask(id: UUID(), name: name, isActive: true, coinRate: coinRate, sortOrder: 0, icon: icon)
     }
 
-    /// TaskCardView 内の全 Text を列挙して文字列で返す。
-    ///
-    /// `find(viewWithAccessibilityIdentifier:)` は ViewInspector 0.10.2 + iOS 26 SDK で
-    /// systematic に効かない既知回帰があるため (CLAUDE.md「SwiftUI View テスト戦略」節)、
-    /// `findAll(ViewType.Text.self)` で blocker を跨いで Text を収集する。
-    private func renderedTexts(_ view: TaskCardView) throws -> [String] {
-        try view.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
-    }
-
     // MARK: - #73 existingCountRow
 
     /// coinInfo (ja "10コイン" / en "10 Coins") を除外した Text に判定文字列が現れるか。
@@ -33,7 +24,7 @@ final class TaskCardViewTests: XCTestCase {
         // iOS 26 + ViewInspector 0.10.2 で当該 API が常に throw するため無条件 pass だった (#177 項目3)。
         // findAll ベースで「coinInfo 以外に数字を含む Text が無い」ことを直接 assert する。
         let view = TaskCardView(task: makeTask(), isSelected: false, existingCount: 0, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertFalse(
             nonCoinTexts(texts).contains { $0.contains(where: \.isNumber) },
             "existingCount(0) なのに件数表示の Text が描画されている。rendered: \(texts)"
@@ -44,7 +35,7 @@ final class TaskCardViewTests: XCTestCase {
         // 文言を exact match しないため locale / 文言変更には依存しない
         // (ja "すでに 1 件記録済み" / en "Already recorded 1 time" のどちらでも "1" を含む)。
         let view = TaskCardView(task: makeTask(), isSelected: false, existingCount: 1, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertTrue(
             nonCoinTexts(texts).contains { $0.contains("1") },
             "existingCount(1) を表す Text が見つからない。描画された Text: \(texts)"
@@ -53,7 +44,7 @@ final class TaskCardViewTests: XCTestCase {
 
     func test_existingCountRow_visible_whenCountIsMany() throws {
         let view = TaskCardView(task: makeTask(), isSelected: false, existingCount: 3, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertTrue(
             nonCoinTexts(texts).contains { $0.contains("3") },
             "existingCount(3) を表す Text が見つからない。描画された Text: \(texts)"
@@ -64,13 +55,13 @@ final class TaskCardViewTests: XCTestCase {
 
     func testRendersExplicitIconEmoji() throws {
         let view = TaskCardView(task: makeTask(icon: "🧹"), isSelected: false, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertTrue(texts.contains("🧹"), "rendered: \(texts)")
     }
 
     func testDefaultTaskRendersDictionaryEmoji() throws {
         let view = TaskCardView(task: makeTask(name: "お風呂を入れる"), isSelected: false, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertTrue(texts.contains("🛁"), "rendered: \(texts)")
     }
 
@@ -85,7 +76,7 @@ final class TaskCardViewTests: XCTestCase {
 
     func testTapToSelectLabelIsRemoved() throws {
         let view = TaskCardView(task: makeTask(), isSelected: false, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertFalse(
             texts.contains { text in Self.tapToSelectVariants.contains { text.contains($0) } },
             "rendered: \(texts)"
@@ -95,7 +86,7 @@ final class TaskCardViewTests: XCTestCase {
     func testSingleModeSelectedShowsNoTextIndicator() throws {
         // 単独モードの選択表現は枠 + チェックマーク overlay のみ (「選択中」テキスト行は削除)
         let view = TaskCardView(task: makeTask(), isSelected: true, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertFalse(
             texts.contains { text in Self.selectedVariants.contains { text.contains($0) } },
             "rendered: \(texts)"
@@ -104,7 +95,7 @@ final class TaskCardViewTests: XCTestCase {
 
     func testBulkModeKeepsSelectionIndicator() throws {
         let view = TaskCardView(task: makeTask(), isSelected: true, isBulkMode: true, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertTrue(
             texts.contains { text in Self.selectedVariants.contains { text.contains($0) } },
             "rendered: \(texts)"
@@ -113,19 +104,10 @@ final class TaskCardViewTests: XCTestCase {
 
     func testSelectedCardUsesBrandPrimaryShapes() throws {
         let view = TaskCardView(task: makeTask(), isSelected: true, onTap: {})
-        let shapes = try view.inspect().findAll(ViewType.Shape.self)
-        let fills = shapes.compactMap { try? $0.fillShapeStyle(Color.self) }
         // #177 項目7: アイコン円 (0.15) とカード背景 (0.1) の両方を個別に assert する (AND)。
         // OR だと片方だけの色 regression を検出できない。findAll(Shape) が
         // .background 内 RoundedRectangle にも到達できることは本テストの GREEN + mutation 検証で実証済み。
-        XCTAssertTrue(
-            fills.contains(AccessibilityColors.brandPrimary.opacity(0.15)),
-            "アイコン円の brandPrimary 0.15 が無い / observed fills: \(fills)"
-        )
-        XCTAssertTrue(
-            fills.contains(AccessibilityColors.brandPrimary.opacity(0.1)),
-            "カード背景の brandPrimary 0.1 が無い / observed fills: \(fills)"
-        )
+        try assertBrandPrimaryIconAndCardFills(view)
     }
 
     /// #151: 未選択カードの背景はダークモードで消えない適応色を使う。
@@ -139,8 +121,7 @@ final class TaskCardViewTests: XCTestCase {
     /// トークン側の値を変えたときにテストが追随する。
     func testUnselectedCardBackgroundUsesAdaptiveColor() throws {
         let view = TaskCardView(task: makeTask(), isSelected: false, onTap: {})
-        let shapes = try view.inspect().findAll(ViewType.Shape.self)
-        let fills = shapes.compactMap { try? $0.fillShapeStyle(Color.self) }
+        let fills = try view.renderedFills()
 
         XCTAssertTrue(
             fills.contains(AccessibilityColors.systemBackgroundSecondary),

--- a/app/OtetsudaiCoinTests/Presentation/Components/TaskIconViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/TaskIconViewTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import OtetsudaiCoin
+
+/// TaskIconView (displayIcon 絵文字 + 選択円塗りの共通 component、#200) のテスト。
+/// findAll ベース (CLAUDE.md「SwiftUI View テスト戦略」節) + トークン定数の等価比較。
+@MainActor
+final class TaskIconViewTests: XCTestCase {
+
+    private func makeTask(name: String = "お風呂を入れる", icon: String? = nil) -> HelpTask {
+        HelpTask(id: UUID(), name: name, isActive: true, coinRate: 10, sortOrder: 0, icon: icon)
+    }
+
+    func testRendersExplicitIconEmoji() throws {
+        let view = TaskIconView(task: makeTask(icon: "🧹"), isSelected: false)
+        let texts = try view.renderedTexts()
+        XCTAssertTrue(texts.contains("🧹"), "rendered: \(texts)")
+    }
+
+    func testUnknownNameFallsBackToSparkle() throws {
+        let view = TaskIconView(task: makeTask(name: "辞書に無い独自タスク"), isSelected: false)
+        let texts = try view.renderedTexts()
+        XCTAssertTrue(texts.contains("✨"), "rendered: \(texts)")
+    }
+
+    func testSelectedCircleUsesSelectedFillToken() throws {
+        let fills = try TaskIconView(task: makeTask(), isSelected: true).renderedFills()
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.taskIconSelectedFill),
+            "選択時の円が taskIconSelectedFill でない / observed fills: \(fills)"
+        )
+    }
+
+    func testUnselectedCircleUsesUnselectedFillToken() throws {
+        let fills = try TaskIconView(task: makeTask(), isSelected: false).renderedFills()
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.taskIconUnselectedFill),
+            "非選択時の円が taskIconUnselectedFill でない / observed fills: \(fills)"
+        )
+    }
+}

--- a/app/OtetsudaiCoinTests/Presentation/Components/TaskRowViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/TaskRowViewTests.swift
@@ -23,25 +23,21 @@ final class TaskRowViewTests: XCTestCase {
         return TaskRowView(task: task, onEdit: {}, onToggle: {}, onDelete: {})
     }
 
-    private func renderedTexts(_ view: TaskRowView) throws -> [String] {
-        try view.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
-    }
-
     /// #177 項目5: 行頭アイコンはタスクの displayIcon 絵文字を表示する (#148 の展開)。
     func test_activeRow_rendersExplicitIconEmoji() throws {
-        let texts = try renderedTexts(makeView(icon: "🧹", isActive: true))
+        let texts = try makeView(icon: "🧹", isActive: true).renderedTexts()
         XCTAssertTrue(texts.contains("🧹"), "rendered: \(texts)")
     }
 
     /// 無効タスクでも絵文字自体は表示される (ミュートは opacity で表現、有効/無効の意味は状態 Text が担う)。
     func test_inactiveRow_stillRendersEmoji() throws {
-        let texts = try renderedTexts(makeView(icon: "🧹", isActive: false))
+        let texts = try makeView(icon: "🧹", isActive: false).renderedTexts()
         XCTAssertTrue(texts.contains("🧹"), "rendered: \(texts)")
     }
 
     /// icon 未設定 & 辞書外名は ✨ へフォールバックする。
     func test_unknownName_fallsBackToSparkle() throws {
-        let texts = try renderedTexts(makeView(name: "辞書に無い独自タスク"))
+        let texts = try makeView(name: "辞書に無い独自タスク").renderedTexts()
         XCTAssertTrue(texts.contains("✨"), "rendered: \(texts)")
     }
 }

--- a/app/OtetsudaiCoinTests/Presentation/Components/TutorialTaskCardViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Components/TutorialTaskCardViewTests.swift
@@ -16,42 +16,30 @@ final class TutorialTaskCardViewTests: XCTestCase {
         HelpTask(id: UUID(), name: name, isActive: true, coinRate: 10, sortOrder: 0, icon: icon)
     }
 
-    private func renderedTexts(_ view: TutorialTaskCardView) throws -> [String] {
-        try view.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
-    }
-
     func testRendersExplicitIconEmoji() throws {
         let view = TutorialTaskCardView(task: makeTask(icon: "🧹"), isSelected: false, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertTrue(texts.contains("🧹"), "rendered: \(texts)")
     }
 
     func testDefaultTaskRendersDictionaryEmoji() throws {
         let view = TutorialTaskCardView(task: makeTask(name: "お風呂を入れる"), isSelected: false, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertTrue(texts.contains("🛁"), "rendered: \(texts)")
     }
 
     func testUnknownNameFallsBackToSparkle() throws {
         let view = TutorialTaskCardView(task: makeTask(name: "辞書に無い独自タスク"), isSelected: false, onTap: {})
-        let texts = try renderedTexts(view)
+        let texts = try view.renderedTexts()
         XCTAssertTrue(texts.contains("✨"), "rendered: \(texts)")
     }
 
     func testSelectedCardUsesBrandPrimaryShapes() throws {
         let view = TutorialTaskCardView(task: makeTask(), isSelected: true, onTap: {})
-        let fills = try view.inspect().findAll(ViewType.Shape.self).compactMap { try? $0.fillShapeStyle(Color.self) }
         // #177 項目7: アイコン円 (0.15) とカード背景 (0.1) の両方を個別に assert する (AND)。
         // OR だと片方だけの色 regression を検出できない。findAll(Shape) が
         // .background 内 RoundedRectangle にも到達できることは本テストの GREEN + mutation 検証で実証済み。
-        XCTAssertTrue(
-            fills.contains(AccessibilityColors.brandPrimary.opacity(0.15)),
-            "アイコン円の brandPrimary 0.15 が無い / observed fills: \(fills)"
-        )
-        XCTAssertTrue(
-            fills.contains(AccessibilityColors.brandPrimary.opacity(0.1)),
-            "カード背景の brandPrimary 0.1 が無い / observed fills: \(fills)"
-        )
+        try assertBrandPrimaryIconAndCardFills(view)
     }
 
 }

--- a/app/OtetsudaiCoinTests/Presentation/Views/HelpHistoryViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Views/HelpHistoryViewTests.swift
@@ -6,6 +6,7 @@ import XCTest
 /// - 日付 fixture は固定絶対日付 (2026-07-15 = 月中日) を使い、実行日非依存にする (#112/#114/#115 の flake 対策)。
 /// - locale は明示的に ja_JP / en_US を渡し、実行環境 locale に依存しない。
 /// - View 本体の traverse は ViewInspector の既知制約があるため行わず、static helper を直接検証する。
+@MainActor
 final class HelpHistoryViewTests: XCTestCase {
 
     /// 2026-07-15 (水) 09:05 を gregorian で固定生成する。
@@ -58,5 +59,17 @@ final class HelpHistoryViewTests: XCTestCase {
         )
         XCTAssertTrue(time.hasPrefix("9:05"), "rendered: \(time)")
         XCTAssertTrue(time.contains("AM"), "rendered: \(time)")
+    }
+
+    // MARK: - timeFormatter cache (#201)
+
+    /// 同一 locale では formatter instance が再利用されること (行 render ごとの生成コスト解消)。
+    func testTimeFormatterIsCachedPerLocale() {
+        let ja1 = HelpHistoryView.timeFormatter(locale: Locale(identifier: "ja_JP"))
+        let ja2 = HelpHistoryView.timeFormatter(locale: Locale(identifier: "ja_JP"))
+        XCTAssertTrue(ja1 === ja2, "同一 locale で formatter が再生成されている")
+
+        let en = HelpHistoryView.timeFormatter(locale: Locale(identifier: "en_US"))
+        XCTAssertFalse(ja1 === en, "locale が異なるのに同一 formatter が返っている")
     }
 }

--- a/app/OtetsudaiCoinTests/Presentation/Views/HelpRecordEditViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Views/HelpRecordEditViewTests.swift
@@ -103,21 +103,21 @@ final class HelpRecordEditViewTests: XCTestCase {
         XCTAssertTrue(texts.contains("✨"), "rendered: \(texts)")
     }
 
-    /// #177 項目5 で導入した円塗りルール (選択 brandPrimary 0.15 / 非選択 gray 0.1) の
+    /// #177 項目5 で導入した円塗りルール (選択 taskIconSelectedFill / 非選択 taskIconUnselectedFill) の
     /// regression guard。項目7 と同じ findAll(Shape) + トークン定数の等価比較パターン。
     func testTaskSelectionRowCircleFillFollowsSelectionState() throws {
         let task = HelpTask(id: UUID(), name: "食器洗い", isActive: true)
 
         let selectedFills = try TaskSelectionRow(task: task, isSelected: true, onSelect: {}).renderedFills()
         XCTAssertTrue(
-            selectedFills.contains(AccessibilityColors.brandPrimary.opacity(0.15)),
-            "選択時の円が brandPrimary 0.15 でない / observed fills: \(selectedFills)"
+            selectedFills.contains(AccessibilityColors.taskIconSelectedFill),
+            "選択時の円が taskIconSelectedFill でない / observed fills: \(selectedFills)"
         )
 
         let unselectedFills = try TaskSelectionRow(task: task, isSelected: false, onSelect: {}).renderedFills()
         XCTAssertTrue(
-            unselectedFills.contains(Color.gray.opacity(0.1)),
-            "非選択時の円が gray 0.1 でない / observed fills: \(unselectedFills)"
+            unselectedFills.contains(AccessibilityColors.taskIconUnselectedFill),
+            "非選択時の円が taskIconUnselectedFill でない / observed fills: \(unselectedFills)"
         )
     }
 }

--- a/app/OtetsudaiCoinTests/Presentation/Views/HelpRecordEditViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Views/HelpRecordEditViewTests.swift
@@ -4,13 +4,13 @@ import ViewInspector
 @testable import OtetsudaiCoin
 
 
+@MainActor
 final class HelpRecordEditViewTests: XCTestCase {
-    
+
     private var mockHelpRecordRepository: MockHelpRecordRepository!
     private var mockHelpTaskRepository: MockHelpTaskRepository!
     private var viewModel: HelpRecordEditViewModel!
-    
-    @MainActor
+
     override func setUp() {
         super.setUp()
         mockHelpRecordRepository = MockHelpRecordRepository()
@@ -34,7 +34,6 @@ final class HelpRecordEditViewTests: XCTestCase {
         super.tearDown()
     }
     
-    @MainActor
     func testHelpRecordEditViewDisplaysTitle() throws {
         // Given
         let view = HelpRecordEditView(viewModel: viewModel)
@@ -43,7 +42,6 @@ final class HelpRecordEditViewTests: XCTestCase {
         XCTAssertNoThrow(try view.inspect())
     }
     
-    @MainActor
     func testHelpRecordEditViewDisplaysForm() throws {
         // Given
         let view = HelpRecordEditView(viewModel: viewModel)
@@ -52,7 +50,6 @@ final class HelpRecordEditViewTests: XCTestCase {
         XCTAssertNoThrow(try view.inspect())
     }
     
-    @MainActor
     func testHelpRecordEditViewDisplaysDatePicker() throws {
         // Given
         let view = HelpRecordEditView(viewModel: viewModel)
@@ -61,7 +58,6 @@ final class HelpRecordEditViewTests: XCTestCase {
         XCTAssertNoThrow(try view.inspect().find(text: "日時", locale: Locale(identifier: "ja")))
     }
     
-    @MainActor
     func testHelpRecordEditViewDisplaysDeleteButton() throws {
         // Given
         let view = HelpRecordEditView(viewModel: viewModel)
@@ -70,7 +66,6 @@ final class HelpRecordEditViewTests: XCTestCase {
         XCTAssertNoThrow(try view.inspect().find(text: "記録を削除", locale: Locale(identifier: "ja")))
     }
     
-    @MainActor
     func testTaskSelectionRowDisplaysTaskInfo() throws {
         // Given
         let task = HelpTask(id: UUID(), name: "食器洗い", isActive: true)
@@ -81,7 +76,6 @@ final class HelpRecordEditViewTests: XCTestCase {
         XCTAssertNoThrow(try row.inspect().find(text: "お手伝いタスク", locale: Locale(identifier: "ja")))
     }
     
-    @MainActor
     func testTaskSelectionRowDisplaysSelectedState() throws {
         // Given
         let task = HelpTask(id: UUID(), name: "食器洗い", isActive: true)
@@ -94,38 +88,33 @@ final class HelpRecordEditViewTests: XCTestCase {
     }
 
     /// #177 項目5: タスク選択行のアイコンは displayIcon 絵文字を表示する (#148 の展開)。
-    @MainActor
     func testTaskSelectionRowRendersDisplayIconEmoji() throws {
         let task = HelpTask(id: UUID(), name: "食器洗い", isActive: true, coinRate: 10, sortOrder: 0, icon: "🧽")
         let row = TaskSelectionRow(task: task, isSelected: false, onSelect: {})
-        let texts = try row.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+        let texts = try row.renderedTexts()
         XCTAssertTrue(texts.contains("🧽"), "rendered: \(texts)")
     }
 
     /// icon 未設定 & 辞書外名は ✨ へフォールバックする。
-    @MainActor
     func testTaskSelectionRowFallsBackToSparkle() throws {
         let task = HelpTask(id: UUID(), name: "辞書に無い独自タスク", isActive: true)
         let row = TaskSelectionRow(task: task, isSelected: false, onSelect: {})
-        let texts = try row.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+        let texts = try row.renderedTexts()
         XCTAssertTrue(texts.contains("✨"), "rendered: \(texts)")
     }
 
     /// #177 項目5 で導入した円塗りルール (選択 brandPrimary 0.15 / 非選択 gray 0.1) の
     /// regression guard。項目7 と同じ findAll(Shape) + トークン定数の等価比較パターン。
-    @MainActor
     func testTaskSelectionRowCircleFillFollowsSelectionState() throws {
         let task = HelpTask(id: UUID(), name: "食器洗い", isActive: true)
 
-        let selectedFills = try TaskSelectionRow(task: task, isSelected: true, onSelect: {})
-            .inspect().findAll(ViewType.Shape.self).compactMap { try? $0.fillShapeStyle(Color.self) }
+        let selectedFills = try TaskSelectionRow(task: task, isSelected: true, onSelect: {}).renderedFills()
         XCTAssertTrue(
             selectedFills.contains(AccessibilityColors.brandPrimary.opacity(0.15)),
             "選択時の円が brandPrimary 0.15 でない / observed fills: \(selectedFills)"
         )
 
-        let unselectedFills = try TaskSelectionRow(task: task, isSelected: false, onSelect: {})
-            .inspect().findAll(ViewType.Shape.self).compactMap { try? $0.fillShapeStyle(Color.self) }
+        let unselectedFills = try TaskSelectionRow(task: task, isSelected: false, onSelect: {}).renderedFills()
         XCTAssertTrue(
             unselectedFills.contains(Color.gray.opacity(0.1)),
             "非選択時の円が gray 0.1 でない / observed fills: \(unselectedFills)"

--- a/app/OtetsudaiCoinTests/Presentation/Views/StoreLoadErrorViewTests.swift
+++ b/app/OtetsudaiCoinTests/Presentation/Views/StoreLoadErrorViewTests.swift
@@ -19,7 +19,7 @@ final class StoreLoadErrorViewTests: XCTestCase {
         // 文言の exact match は locale 依存になるため、見出し + 案内文の 2 つの Text が
         // 描画されること（locale 非依存の構造）を確認する。実文言は simulator 視覚確認で担保。
         let view = StoreLoadErrorView()
-        let texts = try view.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+        let texts = try view.renderedTexts()
         XCTAssertGreaterThanOrEqual(
             texts.count, 2,
             "expected title + guidance Text (>=2); rendered: \(texts)"

--- a/docs/superpowers/plans/2026-08-23-issue-200-201-taskiconview-formatter-cache.md
+++ b/docs/superpowers/plans/2026-08-23-issue-200-201-taskiconview-formatter-cache.md
@@ -1,0 +1,467 @@
+# Issue #200 + #201: TaskIconView 共通化 + timeString formatter cache 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PR #198 の whole-branch review が検出した 2 つの follow-up を 1 PR で解消する — #201: `HelpHistoryView.timeString` が行 render ごとに `DateFormatter` を生成する perf 問題を locale キーの cache で解消。#200: displayIcon 絵文字 + 選択円塗りの verbatim 三重複を `TaskIconView` component へ集約し、テスト側の重複 (renderedTexts 7 箇所 / AND assert ブロック / `@MainActor` 位置不統一) を Helpers へ共通化。
+
+**Architecture:** #201 は `HelpHistoryView` の static helper 群に `@MainActor` の formatter cache を足すだけ (View body = MainActor からのみ呼ばれる)。#200 は `Presentation/Components/TaskIconView.swift` を新設し、**verbatim 重複の 3 site のみ** (TaskCardView / TutorialTaskCardView / TaskSelectionRow) を置換する。円塗り 2 色は `AccessibilityColors` の named constant へ hoist。リスク仮説「findAll(Text/Shape) が親 View から custom subview 内部へ traverse できるか」(iOS 26 + ViewInspector 0.10.2 で未実証) は Task 4 冒頭の TaskCardView swap 直後のテスト実行で最初に検証する。
+
+**Tech Stack:** SwiftUI / XCTest + ViewInspector 0.10.2 / xcodebuild (iPhone 17 Pro Max simulator、2026-08-23 実在確認済み)
+
+**Spec:** GitHub Issue #200・#201 本文 + #200 のコメント (claude-review bot 指摘: `@MainActor` 位置統一) が仕様。独立 spec ドキュメントなし。
+
+## Global Constraints
+
+- テストコマンドは FOREGROUND 実行、判定は `grep -E -A6 '\*\* TEST|Failing tests:'` で判定行を直接抽出する (exit code / tail 判定不可)
+- destination: `platform=iOS Simulator,name=iPhone 17 Pro Max` / project: `app/OtetsudaiCoin.xcodeproj` / scheme: `OtetsudaiCoin`
+- 新規 .swift は所定ディレクトリに置くだけで自動認識 (`PBXFileSystemSynchronizedRootGroup`)。pbxproj 編集不要
+- TDD red の skip は (a) コンパイルエラー確定の場合のみ許可し、commit メッセージに skip 理由を明記する
+- 色比較は hex リテラル直書きではなく `AccessibilityColors` の定数参照で行う
+- コミットは issue 単位で分け、PR description で commit → issue の対応を map する
+
+## スコープ判断 (PR description / issue close コメントに転記すること)
+
+- **#200 の「3〜6 site」のうち集約するのは verbatim 重複の 3 site のみ**: `TaskCardView.taskIcon` (50pt 円 / .title2)、`TutorialTaskCardView` (RecordTutorialView.swift:436-446、50pt 円 / .title2)、`TaskSelectionRow` (HelpRecordEditView.swift:166-173、32pt 円 / .title3)。
+- **意図的に残す 2 site**: `HelpRecordRow` (HelpHistoryView.swift:338-353) はテーマカラーグラデリング + 内側適応色ディスクの別デザイン、`TaskRowView` (TaskManagementView.swift:123-128) は円なしの素 Text + minWidth。強制的に統合すると誰も求めていない style enum が必要になり (YAGNI)、#151/#155 で再デザインされる可能性もある。
+- **site 数の整合**: issue 本文の「6 site」は grep 上の `displayIcon` 出現数で、表示 site は実際には 5 (HelpTask.swift:96 は定義、TaskManagementView:256 はフォーム state 代入で表示でない)。
+
+---
+
+### Task 1: #201 timeString の formatter cache 化 (+ HelpHistoryViewTests の @MainActor クラスレベル化)
+
+**Files:**
+- Modify: `app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift:263-273` (timeString)
+- Test: `app/OtetsudaiCoinTests/Presentation/Views/HelpHistoryViewTests.swift`
+
+**Interfaces:**
+- Consumes: 既存 `HelpHistoryView.timeString(from:locale:)` (HelpRecordRow.body:362 から呼ばれる)
+- Produces: `@MainActor static func timeFormatter(locale: Locale) -> DateFormatter` (cache された instance を返す)。`timeString` は signature 不変だが `@MainActor` が付く
+
+**設計メモ:** cache を `@MainActor` にすると **actor isolation チェックは strict-concurrency レベルに関係なく効く**ため、現在 isolation 注釈なしの `HelpHistoryViewTests` からの同期呼び出しがコンパイルエラーになる。クラスレベル `@MainActor` 付与を本 Task に含める (これは #200 コメントの「`@MainActor` はクラスレベルへ統一」とも整合)。呼び出し元の `HelpRecordRow.body` は View body = MainActor なので変更不要。
+
+- [ ] **Step 1: 失敗するテストを書く** — `HelpHistoryViewTests` に以下を追加し、クラス宣言に `@MainActor` を付ける
+
+```swift
+// クラス宣言を変更 (#200 の @MainActor クラスレベル統一と同方針):
+@MainActor
+final class HelpHistoryViewTests: XCTestCase {
+```
+
+```swift
+    // MARK: - timeFormatter cache (#201)
+
+    /// 同一 locale では formatter instance が再利用されること (行 render ごとの生成コスト解消)。
+    func testTimeFormatterIsCachedPerLocale() {
+        let ja1 = HelpHistoryView.timeFormatter(locale: Locale(identifier: "ja_JP"))
+        let ja2 = HelpHistoryView.timeFormatter(locale: Locale(identifier: "ja_JP"))
+        XCTAssertTrue(ja1 === ja2, "同一 locale で formatter が再生成されている")
+
+        let en = HelpHistoryView.timeFormatter(locale: Locale(identifier: "en_US"))
+        XCTAssertFalse(ja1 === en, "locale が異なるのに同一 formatter が返っている")
+    }
+```
+
+- [ ] **Step 2: red 確認は skip (条件 (a))** — `timeFormatter` が未定義のため `BUILD FAILED` 必至のコンパイルエラー red。実行せず、Step 5 の commit メッセージに「red は timeFormatter 未定義のコンパイルエラー確定のため skip (CLAUDE.md 条件 (a))」と明記する
+
+- [ ] **Step 3: 実装** — `HelpHistoryView.swift` の `timeString` (263-273 行) を以下へ置換
+
+```swift
+    /// 記録時刻 formatter の locale 別 cache (#201)。
+    /// 旧実装は呼び出し (= HelpRecordRow の行 render) ごとに DateFormatter を生成しており、
+    /// 長い履歴リストのスクロールで全可視行分の生成+設定コストが発生していた。
+    /// View body (= MainActor) からしか呼ばれないため @MainActor で隔離し、
+    /// 素の static var の data race を避ける。
+    @MainActor
+    private static var timeFormatterCache: [String: DateFormatter] = [:]
+
+    /// locale に対応する時刻 formatter を返す (cache 済みなら再利用)。
+    @MainActor
+    static func timeFormatter(locale: Locale) -> DateFormatter {
+        if let cached = timeFormatterCache[locale.identifier] {
+            return cached
+        }
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.locale = locale
+        timeFormatterCache[locale.identifier] = formatter
+        return formatter
+    }
+
+    /// 記録時刻を locale に応じて生成する (#155 コメント報告の i18n 漏れ対応)。
+    ///
+    /// 旧実装は `HelpRecordRow` 内の private func で ja_JP 固定になっており、
+    /// en ロケールでも 24 時間表記が強制されていた。`.short` スタイルは
+    /// ja で「9:05」(現行と同一)、en で「9:05 AM」になる。
+    @MainActor
+    static func timeString(from date: Date, locale: Locale) -> String {
+        timeFormatter(locale: locale).string(from: date)
+    }
+```
+
+- [ ] **Step 4: テスト実行 → PASS 確認**
+
+```bash
+LOG=/tmp/t1.log; xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:OtetsudaiCoinTests/HelpHistoryViewTests > "$LOG" 2>&1; \
+  grep -E -A6 '\*\* TEST|Failing tests:' "$LOG"
+```
+
+Expected: `** TEST SUCCEEDED **` (既存 ja/en 非退行テスト 4 件 + 新規 cache テスト 1 件)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/OtetsudaiCoin/Presentation/Views/HelpHistoryView.swift \
+        app/OtetsudaiCoinTests/Presentation/Views/HelpHistoryViewTests.swift
+git commit -m "perf(#201): timeString の DateFormatter を locale 別 cache 化 (行 render ごとの生成を解消)
+
+- @MainActor static cache (View body からのみ呼ばれる) + instance 再利用テスト
+- HelpHistoryViewTests を @MainActor クラスレベルへ (isolation 上の必須 + #200 統一方針)
+- TDD red は timeFormatter 未定義のコンパイルエラー確定のため skip (CLAUDE.md 条件 (a))"
+```
+
+---
+
+### Task 2: テスト共通 helper (renderedTexts / renderedFills / AND assert) + @MainActor 統一
+
+**Files:**
+- Create: `app/OtetsudaiCoinTests/Helpers/ViewInspectorHelpers.swift`
+- Modify: `app/OtetsudaiCoinTests/Presentation/Components/TaskCardViewTests.swift` (private renderedTexts 削除・helper 呼び出し化・AND assert を共通 helper 化)
+- Modify: `app/OtetsudaiCoinTests/Presentation/Components/TutorialTaskCardViewTests.swift` (同上)
+- Modify: `app/OtetsudaiCoinTests/Presentation/Components/TaskRowViewTests.swift` (private renderedTexts 削除)
+- Modify: `app/OtetsudaiCoinTests/Presentation/Components/HelpRecordRowTests.swift:99,106` (inline 2 箇所)
+- Modify: `app/OtetsudaiCoinTests/Presentation/Views/HelpRecordEditViewTests.swift:101,110` (inline 2 箇所 + @MainActor クラスレベル化)
+- Modify: `app/OtetsudaiCoinTests/Presentation/Views/StoreLoadErrorViewTests.swift:22` (inline 1 箇所)
+
+**Interfaces:**
+- Produces: `View.renderedTexts() throws -> [String]`、`View.renderedFills() throws -> [Color]`、`XCTestCase.assertBrandPrimaryIconAndCardFills(_:file:line:) throws` — Task 3 / Task 4 のテストはこれらを使う
+
+**注:** `RecordCalendarViewTests:173` は取得済み配列の compactMap で形が異なるため対象外。これは純テストリファクタで **新規 red は無い** — 既存 suite green がゲート (mutation 検証済みの AND テストが green を保つこと自体が担保)。
+
+- [ ] **Step 1: helper ファイルを作成**
+
+```swift
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import OtetsudaiCoin
+
+/// ViewInspector 共通 helper (#200)。
+/// `find(viewWithAccessibilityIdentifier:)` は ViewInspector 0.10.2 + iOS 26 SDK で
+/// systematic に効かない既知回帰があるため (CLAUDE.md「SwiftUI View テスト戦略」節)、
+/// findAll ベースで blocker を跨いで収集するパターンを 1 箇所に固定する。
+@MainActor
+extension View {
+    /// 描画された全 Text の文字列を列挙する。
+    func renderedTexts() throws -> [String] {
+        try inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+    }
+
+    /// 描画された全 Shape の fill 色を列挙する。
+    func renderedFills() throws -> [Color] {
+        try inspect().findAll(ViewType.Shape.self).compactMap { try? $0.fillShapeStyle(Color.self) }
+    }
+}
+
+extension XCTestCase {
+    /// #177 項目7 で確立した AND assert (アイコン円 0.15 + カード背景 0.1 を個別検証) の共通化 (#200)。
+    /// OR だと片方だけの色 regression を検出できない。両辺の検出力は PR #198 の mutation 検証で実証済み。
+    @MainActor
+    func assertBrandPrimaryIconAndCardFills(
+        _ view: some View, file: StaticString = #filePath, line: UInt = #line
+    ) throws {
+        let fills = try view.renderedFills()
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.brandPrimary.opacity(0.15)),
+            "アイコン円の brandPrimary 0.15 が無い / observed fills: \(fills)", file: file, line: line
+        )
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.brandPrimary.opacity(0.1)),
+            "カード背景の brandPrimary 0.1 が無い / observed fills: \(fills)", file: file, line: line
+        )
+    }
+}
+```
+
+- [ ] **Step 2: 各テストを helper 呼び出しへ置換**
+  - `TaskCardViewTests`: private `renderedTexts(_:)` func (18-20 行) を削除し、呼び出しを `try renderedTexts(view)` → `try view.renderedTexts()` へ (6 箇所)。`testSelectedCardUsesBrandPrimaryShapes` の body を `try assertBrandPrimaryIconAndCardFills(view)` へ。`testUnselectedCardBackgroundUsesAdaptiveColor` の findAll 2 行を `try view.renderedFills()` へ
+  - `TutorialTaskCardViewTests`: 同様 (private func 削除、`testSelectedCardUsesBrandPrimaryShapes` を共通 helper 化)
+  - `TaskRowViewTests`: private renderedTexts func を削除して helper 呼び出しへ
+  - `HelpRecordRowTests` / `HelpRecordEditViewTests` / `StoreLoadErrorViewTests`: inline の `try X.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }` を `try X.renderedTexts()` へ
+  - `HelpRecordEditViewTests`: クラス宣言へ `@MainActor` を付け、メソッド/`setUp` の個別 `@MainActor` を全削除 (#200 コメントの統一項目)
+
+- [ ] **Step 3: 対象テストを実行 → 全 PASS 確認**
+
+```bash
+LOG=/tmp/t2.log; xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:OtetsudaiCoinTests/TaskCardViewTests \
+  -only-testing:OtetsudaiCoinTests/TutorialTaskCardViewTests \
+  -only-testing:OtetsudaiCoinTests/TaskRowViewTests \
+  -only-testing:OtetsudaiCoinTests/HelpRecordRowTests \
+  -only-testing:OtetsudaiCoinTests/HelpRecordEditViewTests \
+  -only-testing:OtetsudaiCoinTests/StoreLoadErrorViewTests > "$LOG" 2>&1; \
+  grep -E -A6 '\*\* TEST|Failing tests:' "$LOG"
+```
+
+Expected: `** TEST SUCCEEDED **`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/OtetsudaiCoinTests
+git commit -m "test(#200): ViewInspector 共通 helper (renderedTexts/renderedFills/AND assert) を Helpers へ抽出、@MainActor をクラスレベルへ統一
+
+純テストリファクタのため新規 red なし (既存 suite green + mutation 検証済み AND テストの green 維持がゲート)"
+```
+
+---
+
+### Task 3: TaskIconView component + AccessibilityColors 定数 hoist + component テスト
+
+**Files:**
+- Create: `app/OtetsudaiCoin/Presentation/Components/TaskIconView.swift`
+- Modify: `app/OtetsudaiCoin/Utils/AccessibilityColors.swift` (Brand Colors 節の末尾、brandSurfaceWarm:132 の後に 2 定数追加)
+- Test: `app/OtetsudaiCoinTests/Presentation/Components/TaskIconViewTests.swift` (新規)
+
+**Interfaces:**
+- Consumes: `HelpTask.displayIcon` (Domain/Entities/HelpTask.swift:96)、Task 2 の `renderedTexts()` / `renderedFills()`
+- Produces: `TaskIconView(task: HelpTask, isSelected: Bool, size: CGFloat = 50, font: Font = .title2)`、`AccessibilityColors.taskIconSelectedFill` / `.taskIconUnselectedFill` — Task 4 が 3 site の置換に使う
+
+- [ ] **Step 1: 失敗するテストを書く** — `TaskIconViewTests.swift` を新規作成
+
+```swift
+import XCTest
+import SwiftUI
+import ViewInspector
+@testable import OtetsudaiCoin
+
+/// TaskIconView (displayIcon 絵文字 + 選択円塗りの共通 component、#200) のテスト。
+/// findAll ベース (CLAUDE.md「SwiftUI View テスト戦略」節) + トークン定数の等価比較。
+@MainActor
+final class TaskIconViewTests: XCTestCase {
+
+    private func makeTask(name: String = "お風呂を入れる", icon: String? = nil) -> HelpTask {
+        HelpTask(id: UUID(), name: name, isActive: true, coinRate: 10, sortOrder: 0, icon: icon)
+    }
+
+    func testRendersExplicitIconEmoji() throws {
+        let view = TaskIconView(task: makeTask(icon: "🧹"), isSelected: false)
+        let texts = try view.renderedTexts()
+        XCTAssertTrue(texts.contains("🧹"), "rendered: \(texts)")
+    }
+
+    func testUnknownNameFallsBackToSparkle() throws {
+        let view = TaskIconView(task: makeTask(name: "辞書に無い独自タスク"), isSelected: false)
+        let texts = try view.renderedTexts()
+        XCTAssertTrue(texts.contains("✨"), "rendered: \(texts)")
+    }
+
+    func testSelectedCircleUsesSelectedFillToken() throws {
+        let fills = try TaskIconView(task: makeTask(), isSelected: true).renderedFills()
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.taskIconSelectedFill),
+            "選択時の円が taskIconSelectedFill でない / observed fills: \(fills)"
+        )
+    }
+
+    func testUnselectedCircleUsesUnselectedFillToken() throws {
+        let fills = try TaskIconView(task: makeTask(), isSelected: false).renderedFills()
+        XCTAssertTrue(
+            fills.contains(AccessibilityColors.taskIconUnselectedFill),
+            "非選択時の円が taskIconUnselectedFill でない / observed fills: \(fills)"
+        )
+    }
+}
+```
+
+- [ ] **Step 2: red 確認は skip (条件 (a))** — `TaskIconView` / 定数が未定義のためコンパイルエラー red 確定。commit メッセージに明記
+
+- [ ] **Step 3: 実装** — まず `AccessibilityColors.swift` の `brandSurfaceWarm` (132 行) の直後に追加:
+
+```swift
+    /// タスクアイコン円の塗り (選択時)。TaskIconView で使用 (#200 で 3 site から hoist)。
+    static let taskIconSelectedFill = brandPrimary.opacity(0.15)
+
+    /// タスクアイコン円の塗り (非選択時)。TaskIconView で使用 (#200 で 3 site から hoist)。
+    static let taskIconUnselectedFill = Color.gray.opacity(0.1)
+```
+
+次に `TaskIconView.swift` を新規作成:
+
+```swift
+import SwiftUI
+
+/// displayIcon 絵文字 + 選択状態の円塗りを表示する共通アイコン (#200)。
+///
+/// TaskCardView / TutorialTaskCardView / TaskSelectionRow で verbatim 重複していた
+/// ZStack + Circle + Text を集約する。tint / font 変更時の追随がここ 1 箇所で済む。
+///
+/// - ZStack + 非拘束 Text: 固定 frame + overlay/background だと AX サイズの
+///   Dynamic Type で絵文字が truncate する (#177 PR #198 で確立したパターン)。
+/// - 絵文字は装飾。意味は隣接する displayName の Text が担うため VoiceOver から隠す (#84 パターン)。
+struct TaskIconView: View {
+    let task: HelpTask
+    let isSelected: Bool
+    var size: CGFloat = 50
+    var font: Font = .title2
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(isSelected
+                    ? AccessibilityColors.taskIconSelectedFill
+                    : AccessibilityColors.taskIconUnselectedFill)
+                .frame(width: size, height: size)
+
+            Text(task.displayIcon)
+                .font(font)
+                .accessibilityHidden(true)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: テスト実行 → PASS 確認**
+
+```bash
+LOG=/tmp/t3.log; xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:OtetsudaiCoinTests/TaskIconViewTests > "$LOG" 2>&1; \
+  grep -E -A6 '\*\* TEST|Failing tests:' "$LOG"
+```
+
+Expected: `** TEST SUCCEEDED **`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/OtetsudaiCoin/Presentation/Components/TaskIconView.swift \
+        app/OtetsudaiCoin/Utils/AccessibilityColors.swift \
+        app/OtetsudaiCoinTests/Presentation/Components/TaskIconViewTests.swift
+git commit -m "feat(#200): TaskIconView component 新設 + 円塗り 2 色を AccessibilityColors へ hoist
+
+- TDD red は TaskIconView / 定数未定義のコンパイルエラー確定のため skip (CLAUDE.md 条件 (a))"
+```
+
+---
+
+### Task 4: 3 site を TaskIconView へ置換 (TaskCardView 先行 = findAll traverse の実証ゲート) + mutation 検証
+
+**Files:**
+- Modify: `app/OtetsudaiCoin/Presentation/Components/TaskCardView.swift:58-69` (taskIcon)
+- Modify: `app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift:436-446` (TutorialTaskCardView 内 ZStack)
+- Modify: `app/OtetsudaiCoin/Presentation/Views/HelpRecordEditView.swift:158-173` (TaskSelectionRow 内 ZStack)
+- Modify (必要時のみ): `app/OtetsudaiCoinTests/Presentation/Views/HelpRecordEditViewTests.swift:127-132` (gray.opacity(0.1) 参照 → `taskIconUnselectedFill` 定数参照へ)
+
+**Interfaces:**
+- Consumes: Task 3 の `TaskIconView(task:isSelected:size:font:)` と fill 定数
+
+**リスクゲート:** 「親 View への `findAll(Text/Shape)` が custom subview (TaskIconView) の内部まで traverse できるか」は本リポで**未実証** (既存実績は component 直接 inspect のみ、#106 ルールの「未検証機構」領域)。TaskCardView を最初に swap して即テストし、fills/texts の dump で即診断する。**FAIL した場合の fallback**: 親テストは `find(TaskIconView.self)` + `actualView().isSelected` の wiring 検証に切替え、アイコン円 fill の assert は TaskIconViewTests 側へ移し、カード背景 (brandPrimary 0.1) の assert は親テストに残す。fallback 採用時は commit メッセージ + PR `## Plan からの逸脱` に明記。
+
+- [ ] **Step 1: TaskCardView を置換** — `taskIcon` (58-69 行) を以下へ:
+
+```swift
+    private var taskIcon: some View {
+        // ZStack + 非拘束 Text / VoiceOver hidden / 円塗りトークンは TaskIconView に集約 (#200)
+        TaskIconView(task: task, isSelected: isSelected)
+    }
+```
+
+- [ ] **Step 2: 実証ゲート — TaskCardViewTests を即実行**
+
+```bash
+LOG=/tmp/t4a.log; xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:OtetsudaiCoinTests/TaskCardViewTests > "$LOG" 2>&1; \
+  grep -E -A6 '\*\* TEST|Failing tests:' "$LOG"
+```
+
+Expected: `** TEST SUCCEEDED **` = findAll が component 境界を跨げると実証 → Step 3 へ。FAIL なら上記 fallback に切替えて (assert 移設後に green を確認して) から Step 3 へ
+
+- [ ] **Step 3: TutorialTaskCardView を置換** — RecordTutorialView.swift:436-446 の ZStack ブロックを:
+
+```swift
+                // ZStack + 非拘束 Text / VoiceOver hidden / 円塗りトークンは TaskIconView に集約 (#200)
+                TaskIconView(task: task, isSelected: isSelected)
+```
+
+- [ ] **Step 4: TaskSelectionRow を置換** — HelpRecordEditView.swift:158-173 のコメント + ZStack ブロックを:
+
+```swift
+                // タスクアイコン (32pt / .title3 は行レイアウト用の縮小版)。
+                // ZStack + 非拘束 Text / VoiceOver hidden / 円塗りトークンは TaskIconView に集約 (#200)
+                TaskIconView(task: task, isSelected: isSelected, size: 32, font: .title3)
+```
+
+- [ ] **Step 5: テスト側の色参照を定数へ揃える** — `HelpRecordEditViewTests.testTaskSelectionRowCircleFillFollowsSelectionState` の `AccessibilityColors.brandPrimary.opacity(0.15)` → `AccessibilityColors.taskIconSelectedFill`、`Color.gray.opacity(0.1)` → `AccessibilityColors.taskIconUnselectedFill` (single source 化。値は同一なので挙動不変)
+
+- [ ] **Step 6: 関連 component テストを一括実行 → PASS 確認**
+
+```bash
+LOG=/tmp/t4b.log; xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:OtetsudaiCoinTests/TaskCardViewTests \
+  -only-testing:OtetsudaiCoinTests/TutorialTaskCardViewTests \
+  -only-testing:OtetsudaiCoinTests/TaskIconViewTests \
+  -only-testing:OtetsudaiCoinTests/HelpRecordEditViewTests > "$LOG" 2>&1; \
+  grep -E -A6 '\*\* TEST|Failing tests:' "$LOG"
+```
+
+Expected: `** TEST SUCCEEDED **`
+
+- [ ] **Step 7: mutation 検証** — 置換は pure refactor で red が原理的に出ないため、CLAUDE.md「厳格化テスト変更では mutation 検証を red の代替とする」ルールに従い検出力を実証する: `TaskIconView` の `taskIconSelectedFill` を一時的に `taskIconUnselectedFill` へ書き換え → Step 6 のコマンドを再実行して **TaskCardViewTests / TutorialTaskCardViewTests / TaskIconViewTests / HelpRecordEditViewTests が FAIL** することを確認 → revert して再実行、GREEN 復帰を確認
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/OtetsudaiCoin/Presentation/Components/TaskCardView.swift \
+        app/OtetsudaiCoin/Presentation/Views/Tutorial/RecordTutorialView.swift \
+        app/OtetsudaiCoin/Presentation/Views/HelpRecordEditView.swift \
+        app/OtetsudaiCoinTests/Presentation/Views/HelpRecordEditViewTests.swift
+git commit -m "refactor(#200): displayIcon 円アイコンの verbatim 3 site を TaskIconView へ集約
+
+- findAll(Text/Shape) が component 境界を跨いで traverse できることを TaskCardView swap 直後のテストで実証
+- pure refactor のため red なし。selected fill の mutation 検証で 4 テストクラスの検出力を確認 → revert 済み
+- HelpRecordRow (テーマグラデリング) / TaskRowView (円なし素 Text) は別デザインのため意図的に対象外"
+```
+
+---
+
+### Task 5: 全 unit suite + whole-branch レビュー + PR 作成
+
+**Files:**
+- なし (検証と PR 作成のみ)
+
+- [ ] **Step 1: 全 unit テストを実行**
+
+```bash
+LOG=/tmp/t5.log; xcodebuild test -project app/OtetsudaiCoin.xcodeproj -scheme OtetsudaiCoin \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
+  -only-testing:OtetsudaiCoinTests > "$LOG" 2>&1; \
+  grep -E -A6 '\*\* TEST|Failing tests:' "$LOG"
+```
+
+Expected: `** TEST SUCCEEDED **`。FAIL したら `-only-testing:` の isolated 再実行で parallel flake と regression を切り分ける
+
+- [ ] **Step 2: whole-branch レビュー** — inline 実行でも省略不可 (CLAUDE.md 2026-08-15 ルール)。`git diff origin/main...HEAD` を全読みし、spec (#200/#201) との突合 + code-quality 観点 (特に: cache の isolation、helper 抽出でのコスト特性変化、コメントの stale 化) でレビューする。指摘があれば fix commit を積む
+
+- [ ] **Step 3: push 直前の HEAD 再確認 + 既存 PR 確認**
+
+```bash
+git status --short --branch
+gh pr list --head feature/issue-200-201-taskiconview-and-formatter
+```
+
+- [ ] **Step 4: push + PR 作成** — PR description に含めること: (a) 冒頭のスコープ判断節 (3/6 site の意図的限定 + site 数の整合)、(b) commit → issue の対応表、(c) `## Plan からの逸脱` (あれば。fallback 採用時は必須)、(d) `Closes #200` / `Closes #201`
+
+- [ ] **Step 5: #200 へ close 前提のコメントを 1 件投稿** — 「HelpRecordRow (グラデリング) / TaskRowView (素 Text) は別デザインのため意図的に未集約 (#151/#155 の再デザインで再検討)」というスコープ判断を、PR link と共に issue 側にも残す
+
+---
+
+## Self-Review 済み事項
+
+- **Spec coverage**: #201 (cache + 非退行テスト) → Task 1。#200 項目1 (円塗り ternary 三重複) → Task 3+4。項目2 (絵文字 unit 6 箇所) → 3 site 集約 + スコープ判断節で残り 2 site の理由を明文化。項目3a (AND assert 重複) / 3b (renderedTexts 7 箇所) → Task 2。コメント項目 (@MainActor 統一) → Task 1 (HelpHistoryViewTests) + Task 2 (HelpRecordEditViewTests)。
+- **Type consistency**: `TaskIconView(task:isSelected:size:font:)` の引数順は Swift の「let 先・default 後」に従い全 Task で一致。`renderedTexts()`/`renderedFills()`/`assertBrandPrimaryIconAndCardFills(_:file:line:)` の名前は Task 2 定義と Task 3/4 使用で一致。
+- **既存テスト名の温存**: TaskCardViewTests / TutorialTaskCardViewTests のテストメソッド名は変えない (helper 化は body のみ)。


### PR DESCRIPTION
## 概要

PR #198 の whole-branch review から生まれた 2 つの follow-up を解消します。

- **Closes #200**: displayIcon 絵文字 + 選択円塗りの verbatim 三重複を `TaskIconView` component へ集約し、テスト側の重複 (renderedTexts inline 収集 7+ 箇所 / AND assert ブロック / `@MainActor` 位置不統一) を `Helpers/ViewInspectorHelpers.swift` へ共通化
- **Closes #201**: `HelpHistoryView.timeString` が行 render ごとに `DateFormatter` を生成していた perf 問題を、locale 別 `@MainActor` static cache で解消

## スコープ判断 (#200 の「3〜6 site」について)

- **集約したのは verbatim 重複の 3 site のみ**: `TaskCardView.taskIcon` (50pt/.title2) / `TutorialTaskCardView` (50pt/.title2) / `TaskSelectionRow` (32pt/.title3)
- **意図的に残した 2 site**: `HelpRecordRow` はテーマカラーグラデリング + 内側適応色ディスクの別デザイン、`TaskRowView` は円なしの素 Text + minWidth。強制統合は style enum の過剰設計 (YAGNI) になり、#151/#155 の再デザインで形が変わる可能性もあるため見送り
- **site 数の整合**: issue 本文の「6 site」は grep 出現数で、表示 site は実際 5 (`HelpTask.swift:96` は定義、`TaskManagementView:256` はフォーム state 代入)

## Commit → Issue 対応

| Commit | Issue | 内容 |
|---|---|---|
| bef8a88 | #201 | timeString の locale 別 formatter cache + instance 再利用テスト + `HelpHistoryViewTests` の `@MainActor` クラスレベル化 |
| d1937a0 | #200 | `renderedTexts`/`renderedFills`/AND assert の共通 helper 化 + `HelpRecordEditViewTests` の `@MainActor` 統一 |
| df3faa9 | #200 | `TaskIconView` 新設 + 円塗り 2 色を `AccessibilityColors.taskIconSelectedFill/.taskIconUnselectedFill` へ hoist |
| f73e07c | #200 | 3 site を `TaskIconView` へ置換 (mutation 検証で 4 テストクラスの検出力を確認 → revert) |
| fa707e2 | #200 | 最終レビュー指摘反映 (AND helper のアイコン円判定を token 参照へ) |
| 186ca58 | - | 実装計画ドキュメント |

## 検証

- **実証ゲート**: `findAll(Text/Shape)` が custom subview (TaskIconView) 境界を跨いで traverse できるかは本リポ未実証だったため、TaskCardView を最初に swap して即テスト → green で実証 (iOS 26 + ViewInspector 0.10.2)。fallback 不要
- **mutation 検証** (pure refactor で red が出ないため CLAUDE.md ルールの red 代替): selected fill を一時破壊 → TaskCardViewTests / TutorialTaskCardViewTests / TaskIconViewTests / HelpRecordEditViewTests の 4 クラス FAIL 確認 → revert → GREEN 復帰
- **視覚等価性**: 3 site とも円サイズ (50/50/32)・font (.title2/.title2/.title3)・fill 値 (旧リテラルと同一式の token) が置換前と一致 — pixel 等価でダークモード挙動も不変
- **全 unit suite**: `** TEST SUCCEEDED **` (log 内 real exit=0 も確認)
- **TDD red skip**: bef8a88 / df3faa9 はコンパイルエラー確定 (条件 (a)) のため skip、各 commit メッセージに明記

## Plan からの逸脱

- Task 2 のスコープに `HelpRecordEditViewTests` の inline `findAll(Shape)` 2 箇所の helper 化を追加 (controller ruling: helper の single-source 目的に合致)
- Task 4 に trailing newline 復元を追加 (Task 2 review の deferred minor 対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AGJWUP6pKs32t87tvVsXE